### PR TITLE
Basic TAA

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ OpenGL rendering library (for 3d graphics study)
   * Global illumination
     * Cascaded shadow map
     * Screen-space ambient occlusion
-    * Screen-space reflection
+    * Screen-space reflection (WIP)
     * Basic sky IBL
   * Volumetric clouds
   * Post processing
     * God ray (light shaft)
     * Bloom
     * Tone mapping
-    * Anti-aliasing (FXAA)
+    * Anti-aliasing (FXAA, TAA)
     * Super resolution (AMD FSR1)
     * Depth of field
   * Scene capture

--- a/projects/PathosEngine/PathosEngine.vcxproj
+++ b/projects/PathosEngine/PathosEngine.vcxproj
@@ -138,6 +138,8 @@
     <ClCompile Include="src\pathos\render\forward\translucency_rendering.cpp" />
     <ClCompile Include="src\pathos\render\indirect_lighting.cpp" />
     <ClCompile Include="src\pathos\render\irradiance_baker.cpp" />
+    <ClCompile Include="src\pathos\render\postprocessing\anti_aliasing.cpp" />
+    <ClCompile Include="src\pathos\render\postprocessing\anti_aliasing_taa.cpp" />
     <ClCompile Include="src\pathos\render\postprocessing\super_res.cpp" />
     <ClCompile Include="src\pathos\render\postprocessing\super_res_fsr1.cpp" />
     <ClCompile Include="src\pathos\render\postprocessing\anti_aliasing_fxaa.cpp" />
@@ -260,6 +262,7 @@
     <ClInclude Include="src\pathos\render\indirect_lighting.h" />
     <ClInclude Include="src\pathos\render\irradiance_baker.h" />
     <ClInclude Include="src\pathos\render\postprocessing\anti_aliasing.h" />
+    <ClInclude Include="src\pathos\render\postprocessing\anti_aliasing_taa.h" />
     <ClInclude Include="src\pathos\render\postprocessing\super_res_fsr1.h" />
     <ClInclude Include="src\pathos\render\postprocessing\anti_aliasing_fxaa.h" />
     <ClInclude Include="src\pathos\render\postprocessing\bloom.h" />

--- a/projects/PathosEngine/PathosEngine.vcxproj.filters
+++ b/projects/PathosEngine/PathosEngine.vcxproj.filters
@@ -357,6 +357,12 @@
     <ClCompile Include="src\pathos\loader\gltf_loader.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="src\pathos\render\postprocessing\anti_aliasing_taa.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="src\pathos\render\postprocessing\anti_aliasing.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\pathos\mesh\geometry.h">
@@ -777,6 +783,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="src\pathos\loader\gltf_loader.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\pathos\render\postprocessing\anti_aliasing_taa.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/projects/PathosEngine/src/badger/math/random.cpp
+++ b/projects/PathosEngine/src/badger/math/random.cpp
@@ -1,7 +1,7 @@
 #include "random.h"
 #include "glm/gtc/constants.hpp"
 
-glm::vec3 RandomInUnitSphere()
+vector3 RandomInUnitSphere()
 {
 	static thread_local RNG randoms(4096);
 
@@ -11,7 +11,7 @@ glm::vec3 RandomInUnitSphere()
 	float z = 1.0f - 2.0f * u1;
 	float r = sqrt(std::max(0.0f, 1.0f - z * z));
 	float phi = 2.0f * glm::pi<float>() * u2;
-	return glm::vec3(r * cos(phi), r * sin(phi), z);
+	return vector3(r * cos(phi), r * sin(phi), z);
 }
 
 float Random()
@@ -21,7 +21,7 @@ float Random()
 	return randoms.Peek();
 }
 
-glm::vec3 RandomInUnitDisk()
+vector3 RandomInUnitDisk()
 {
 	static thread_local RNG randoms(4096 * 8);
 	float u1 = randoms.Peek();
@@ -29,5 +29,29 @@ glm::vec3 RandomInUnitDisk()
 	float r = sqrt(u1);
 	
 	float theta = 2.0f * glm::pi<float>() * u2;
-	return glm::vec3(r * cos(theta), r * sin(theta), 0.0f);
+	return vector3(r * cos(theta), r * sin(theta), 0.0f);
+}
+
+namespace badger {
+
+	// https://en.wikipedia.org/wiki/Halton_sequence
+	void HaltonSequence(uint32 base, uint32 numSamples, float* dest)
+	{
+		int32 n = 0, d = 1;
+		for (uint32 step = 0; step < numSamples; ++step) {
+			int32 x = d - n;
+			if (x == 1) {
+				n = 1;
+				d *= base;
+			} else {
+				int32 y = d / base;
+				while (x <= y) {
+					y /= base;
+				}
+				n = (base + 1) * y - x;
+			}
+			dest[step] = (float)n / d;
+		}
+	}
+
 }

--- a/projects/PathosEngine/src/badger/math/random.h
+++ b/projects/PathosEngine/src/badger/math/random.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "badger/types/int_types.h"
-
-#include "glm/vec3.hpp"
+#include "badger/types/vector_types.h"
 
 #include <random>
 #include <vector>
@@ -64,8 +63,14 @@ private:
 
 };
 
-glm::vec3 RandomInUnitSphere();
+vector3 RandomInUnitSphere();
 
 float Random();
 
-glm::vec3 RandomInUnitDisk();
+vector3 RandomInUnitDisk();
+
+namespace badger {
+
+	void HaltonSequence(uint32 base, uint32 numSamples, float* dest);
+
+}

--- a/projects/PathosEngine/src/pathos/material/material.h
+++ b/projects/PathosEngine/src/pathos/material/material.h
@@ -26,6 +26,7 @@ namespace pathos {
 
 			// #todo: Upload only object ID. Read model transform from some buffer.
 			matrix4 modelTransform;
+			matrix4 prevModelTransform;
 		};
 
 	private:

--- a/projects/PathosEngine/src/pathos/mesh/static_mesh_component.cpp
+++ b/projects/PathosEngine/src/pathos/mesh/static_mesh_component.cpp
@@ -59,12 +59,15 @@ namespace pathos {
 			proxy->doubleSided = mesh->doubleSided;
 			proxy->renderInternal = mesh->renderInternal;
 			proxy->modelMatrix = getLocalMatrix();
+			proxy->prevModelMatrix = prevModelMatrix;
 			proxy->geometry = G;
 			proxy->material = M;
 			proxy->worldBounds = calculateWorldBounds(proxy->geometry->getLocalBounds(), proxy->modelMatrix);
 
 			scene->addStaticMeshProxy(proxy);
 		}
+
+		prevModelMatrix = getLocalMatrix();
 	}
 
 	AABB StaticMeshComponent::getWorldBounds() const

--- a/projects/PathosEngine/src/pathos/mesh/static_mesh_component.h
+++ b/projects/PathosEngine/src/pathos/mesh/static_mesh_component.h
@@ -15,6 +15,7 @@ namespace pathos {
 		uint32 doubleSided : 1;
 		uint32 renderInternal : 1;
 		matrix4 modelMatrix;
+		matrix4 prevModelMatrix;
 		MeshGeometry* geometry;
 		Material* material;
 		AABB worldBounds;
@@ -49,6 +50,7 @@ namespace pathos {
 
 	private:
 		Mesh* mesh = nullptr;
+		matrix4 prevModelMatrix;
 
 	};
 

--- a/projects/PathosEngine/src/pathos/render/depth_prepass.cpp
+++ b/projects/PathosEngine/src/pathos/render/depth_prepass.cpp
@@ -115,6 +115,7 @@ namespace pathos {
 				{
 					Material::UBO_PerObject uboData;
 					uboData.modelTransform = proxy->modelMatrix;
+					uboData.prevModelTransform = proxy->prevModelMatrix;
 					uboPerObject.update(cmdList, Material::UBO_PerObject::BINDING_POINT, &uboData);
 				}
 

--- a/projects/PathosEngine/src/pathos/render/forward/translucency_rendering.cpp
+++ b/projects/PathosEngine/src/pathos/render/forward/translucency_rendering.cpp
@@ -124,6 +124,7 @@ namespace pathos {
 			{
 				Material::UBO_PerObject uboData;
 				uboData.modelTransform = proxy->modelMatrix;
+				uboData.prevModelTransform = proxy->prevModelMatrix;
 				uboPerObject.update(cmdList, Material::UBO_PerObject::BINDING_POINT, &uboData);
 			}
 

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing.cpp
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing.cpp
@@ -1,0 +1,26 @@
+#include "anti_aliasing.h"
+#include "pathos/console.h"
+#include "badger/math/minmax.h"
+
+namespace pathos {
+
+	static ConsoleVariable<int32> cvar_anti_aliasing(
+		"r.antialiasing.method",
+		2,
+		"0 = None, 1 = FXAA, 2 = TAA");
+
+	static ConsoleVariable<float> cvar_temporalJitterMultiplier(
+		"r.taa.jitterMultiplier",
+		1.0f,
+		"Temporal jitter multiplier");
+
+	EAntiAliasingMethod getAntiAliasingMethod() {
+		int32 total = (int32)EAntiAliasingMethod::NumMethods;
+		return (EAntiAliasingMethod)badger::clamp(0, cvar_anti_aliasing.getInt(), total);
+	}
+
+	float getTemporalJitterMultiplier() {
+		return badger::clamp(0.0f, cvar_temporalJitterMultiplier.getFloat(), 10.0f);
+	}
+
+}

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing.h
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing.h
@@ -7,8 +7,12 @@ namespace pathos {
 	enum class EAntiAliasingMethod : uint8 {
 		NoAA = 0, // Skip anti-aliasing pass
 		FXAA = 1, // NVidia FXAA
-		//TAA = 2, // #todo-anti-aliasing: TAA
-		NumMethods = 2
+		TAA = 2,
+		NumMethods = 3
 	};
+
+	EAntiAliasingMethod getAntiAliasingMethod();
+
+	float getTemporalJitterMultiplier();
 
 }

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
@@ -1,0 +1,38 @@
+#include "anti_aliasing_taa.h"
+#include "pathos/shader/shader_program.h"
+#include "pathos/render/render_device.h"
+#include "pathos/render/scene_render_targets.h"
+#include "pathos/util/engine_util.h"
+
+namespace pathos {
+
+	struct UBO_TAA {
+		static constexpr uint32 BINDING_POINT = 1;
+		
+		vector4 dummy;
+	};
+
+}
+
+namespace pathos {
+
+	void TAA::initializeResources(RenderCommandList& cmdList) {
+		ubo.init<UBO_TAA>("UBO_FXAA");
+
+		gRenderDevice->createFramebuffers(1, &fbo);
+		cmdList.namedFramebufferDrawBuffer(fbo, GL_COLOR_ATTACHMENT0);
+		cmdList.objectLabel(GL_FRAMEBUFFER, fbo, -1, "FBO_TAA");
+	}
+
+	void TAA::releaseResources(RenderCommandList& cmdList) {
+		gRenderDevice->deleteFramebuffers(1, &fbo);
+		markDestroyed();
+	}
+
+	void TAA::renderPostProcess(RenderCommandList& cmdList, PlaneGeometry* fullscreenQuad) {
+		SCOPED_DRAW_EVENT(TAA);
+
+		// #todo-taa
+	}
+
+}

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
@@ -3,21 +3,41 @@
 #include "pathos/render/render_device.h"
 #include "pathos/render/scene_render_targets.h"
 #include "pathos/util/engine_util.h"
+#include "pathos/console.h"
+#include "badger/math/minmax.h"
 
 namespace pathos {
+
+	static ConsoleVariable<float> cvar_taaHistoryWeight("r.taa.historyWeight", 0.9f, "sceneColor history weight");
 
 	struct UBO_TAA {
 		static constexpr uint32 BINDING_POINT = 1;
 		
-		vector4 dummy;
+		float historyWeight;
 	};
+
+	class TemporalAntiAliasingVS : public ShaderStage {
+	public:
+		TemporalAntiAliasingVS() : ShaderStage(GL_VERTEX_SHADER, "TemporalAntiAliasingVS") {
+			setFilepath("fullscreen_quad.glsl");
+		}
+	};
+
+	class TemporalAntiAliasingFS : public ShaderStage {
+	public:
+		TemporalAntiAliasingFS() : ShaderStage(GL_FRAGMENT_SHADER, "TemporalAntiAliasingFS") {
+			setFilepath("temporal_anti_aliasing.glsl");
+		}
+	};
+
+	DEFINE_SHADER_PROGRAM2(Program_TAA, TemporalAntiAliasingVS, TemporalAntiAliasingFS);
 
 }
 
 namespace pathos {
 
 	void TAA::initializeResources(RenderCommandList& cmdList) {
-		ubo.init<UBO_TAA>("UBO_FXAA");
+		ubo.init<UBO_TAA>("UBO_TAA");
 
 		gRenderDevice->createFramebuffers(1, &fbo);
 		cmdList.namedFramebufferDrawBuffer(fbo, GL_COLOR_ATTACHMENT0);
@@ -32,7 +52,35 @@ namespace pathos {
 	void TAA::renderPostProcess(RenderCommandList& cmdList, PlaneGeometry* fullscreenQuad) {
 		SCOPED_DRAW_EVENT(TAA);
 
-		// #todo-taa
+		const GLuint input0 = getInput(EPostProcessInput::PPI_0); // sceneColorToneMapped
+		const GLuint input1 = getInput(EPostProcessInput::PPI_1); // sceneColorHistory
+		const GLuint output0 = getOutput(EPostProcessOutput::PPO_0); // sceneColorAA or sceneFinal
+		CHECKF(output0 != 0, "Post processes do not write to the backbuffer anymore");
+
+		SceneRenderTargets& sceneContext = *cmdList.sceneRenderTargets;
+
+		ShaderProgram& program = FIND_SHADER_PROGRAM(Program_TAA);
+		cmdList.useProgram(program.getGLName());
+
+		UBO_TAA uboData;
+		uboData.historyWeight = badger::clamp(0.0f, cvar_taaHistoryWeight.getFloat(), 1.0f);
+		ubo.update(cmdList, UBO_TAA::BINDING_POINT, &uboData);
+
+		cmdList.bindFramebuffer(GL_FRAMEBUFFER, fbo);
+		cmdList.namedFramebufferTexture(fbo, GL_COLOR_ATTACHMENT0, output0, 0);
+
+		cmdList.viewport(0, 0, sceneContext.sceneWidth, sceneContext.sceneHeight);
+
+		cmdList.textureParameteri(input0, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		cmdList.textureParameteri(input0, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		cmdList.textureParameteri(input1, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		cmdList.textureParameteri(input1, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		cmdList.bindTextureUnit(0, input0);
+		cmdList.bindTextureUnit(1, input1);
+
+		fullscreenQuad->activate_position_uv(cmdList);
+		fullscreenQuad->activateIndexBuffer(cmdList);
+		fullscreenQuad->drawPrimitive(cmdList);
 	}
 
 }

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
@@ -54,6 +54,7 @@ namespace pathos {
 
 		const GLuint input0 = getInput(EPostProcessInput::PPI_0); // sceneColorToneMapped
 		const GLuint input1 = getInput(EPostProcessInput::PPI_1); // sceneColorHistory
+		const GLuint input2 = getInput(EPostProcessInput::PPI_2); // sceneDepth
 		const GLuint output0 = getOutput(EPostProcessOutput::PPO_0); // sceneColorAA or sceneFinal
 		CHECKF(output0 != 0, "Post processes do not write to the backbuffer anymore");
 
@@ -77,6 +78,7 @@ namespace pathos {
 		cmdList.textureParameteri(input1, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		cmdList.bindTextureUnit(0, input0);
 		cmdList.bindTextureUnit(1, input1);
+		cmdList.bindTextureUnit(2, input2);
 
 		fullscreenQuad->activate_position_uv(cmdList);
 		fullscreenQuad->activateIndexBuffer(cmdList);

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.cpp
@@ -55,6 +55,7 @@ namespace pathos {
 		const GLuint input0 = getInput(EPostProcessInput::PPI_0); // sceneColorToneMapped
 		const GLuint input1 = getInput(EPostProcessInput::PPI_1); // sceneColorHistory
 		const GLuint input2 = getInput(EPostProcessInput::PPI_2); // sceneDepth
+		const GLuint input3 = getInput(EPostProcessInput::PPI_3); // velocityMap
 		const GLuint output0 = getOutput(EPostProcessOutput::PPO_0); // sceneColorAA or sceneFinal
 		CHECKF(output0 != 0, "Post processes do not write to the backbuffer anymore");
 
@@ -76,9 +77,12 @@ namespace pathos {
 		cmdList.textureParameteri(input0, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		cmdList.textureParameteri(input1, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		cmdList.textureParameteri(input1, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		cmdList.textureParameteri(input3, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		cmdList.textureParameteri(input3, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		cmdList.bindTextureUnit(0, input0);
 		cmdList.bindTextureUnit(1, input1);
 		cmdList.bindTextureUnit(2, input2);
+		cmdList.bindTextureUnit(3, input3);
 
 		fullscreenQuad->activate_position_uv(cmdList);
 		fullscreenQuad->activateIndexBuffer(cmdList);

--- a/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.h
+++ b/projects/PathosEngine/src/pathos/render/postprocessing/anti_aliasing_taa.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "post_process.h"
+#include "pathos/shader/uniform_buffer.h"
+
+// Temporal anti-aliasing
+
+namespace pathos {
+
+	class TAA final : public PostProcess {
+
+	public:
+		virtual void initializeResources(RenderCommandList& cmdList) override;
+		virtual void releaseResources(RenderCommandList& cmdList) override;
+		virtual void renderPostProcess(RenderCommandList& cmdList, PlaneGeometry* fullscreenQuad) override;
+
+	private:
+		GLuint fbo = 0;
+		UniformBuffer ubo;
+
+	};
+
+}

--- a/projects/PathosEngine/src/pathos/render/scene_render_targets.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_render_targets.cpp
@@ -198,6 +198,7 @@ namespace pathos {
 		// Anti-aliasing
 		static constexpr GLenum PF_sceneColorAA = GL_RGBA16F;
 		reallocTexture2D(sceneColorAA, PF_sceneColorAA, sceneWidth, sceneHeight, "sceneColorAA");
+		reallocTexture2D(sceneColorHistory, PF_sceneColorAA, sceneWidth, sceneHeight, "sceneColorHistory");
 
 		// Tone mapping
 		reallocTexture2D(sceneColorToneMapped, GL_RGBA16F, sceneWidth, sceneHeight, "sceneColorToneMapped");
@@ -252,6 +253,7 @@ namespace pathos {
 		safe_release(sceneColorHalfRes);
 		safe_release(sceneDepth);
 		safe_release(sceneColorAA);
+		safe_release(sceneColorHistory);
 		safe_release(sceneColorUpscaledTemp);
 		safe_release(sceneColorUpscaled);
 		safe_release(sceneFinal);

--- a/projects/PathosEngine/src/pathos/render/scene_render_targets.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_render_targets.cpp
@@ -197,8 +197,10 @@ namespace pathos {
 
 		// Anti-aliasing
 		static constexpr GLenum PF_sceneColorAA = GL_RGBA16F;
+		static constexpr GLenum PF_velocityMap = GL_RG16F;
 		reallocTexture2D(sceneColorAA, PF_sceneColorAA, sceneWidth, sceneHeight, "sceneColorAA");
 		reallocTexture2D(sceneColorHistory, PF_sceneColorAA, sceneWidth, sceneHeight, "sceneColorHistory");
+		reallocTexture2D(velocityMap, PF_velocityMap, sceneWidth, sceneHeight, "velocityMap");
 
 		// Tone mapping
 		reallocTexture2D(sceneColorToneMapped, GL_RGBA16F, sceneWidth, sceneHeight, "sceneColorToneMapped");
@@ -254,6 +256,7 @@ namespace pathos {
 		safe_release(sceneDepth);
 		safe_release(sceneColorAA);
 		safe_release(sceneColorHistory);
+		safe_release(velocityMap);
 		safe_release(sceneColorUpscaledTemp);
 		safe_release(sceneColorUpscaled);
 		safe_release(sceneFinal);

--- a/projects/PathosEngine/src/pathos/render/scene_render_targets.h
+++ b/projects/PathosEngine/src/pathos/render/scene_render_targets.h
@@ -38,6 +38,7 @@ namespace pathos {
 
 		GLuint sceneColorAA = 0; // sceneColor after anti-aliasing pass
 		GLuint sceneColorHistory = 0; // For TAA
+		GLuint velocityMap = 0;
 
 		GLuint sceneColorUpscaledTemp = 0; // FSR1 EASU output
 		GLuint sceneColorUpscaled = 0; // FSR1 RCAS output

--- a/projects/PathosEngine/src/pathos/render/scene_render_targets.h
+++ b/projects/PathosEngine/src/pathos/render/scene_render_targets.h
@@ -37,6 +37,7 @@ namespace pathos {
 		GLuint sceneDepth = 0;
 
 		GLuint sceneColorAA = 0; // sceneColor after anti-aliasing pass
+		GLuint sceneColorHistory = 0; // For TAA
 
 		GLuint sceneColorUpscaledTemp = 0; // FSR1 EASU output
 		GLuint sceneColorUpscaled = 0; // FSR1 RCAS output

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
@@ -18,6 +18,7 @@
 #include "pathos/render/postprocessing/bloom.h"
 #include "pathos/render/postprocessing/tone_mapping.h"
 #include "pathos/render/postprocessing/depth_of_field.h"
+#include "pathos/render/postprocessing/anti_aliasing.h"
 #include "pathos/render/postprocessing/anti_aliasing_fxaa.h"
 #include "pathos/render/postprocessing/super_res.h"
 #include "pathos/render/postprocessing/super_res_fsr1.h"
@@ -38,6 +39,7 @@
 
 #include "badger/assertion/assertion.h"
 #include "badger/math/minmax.h"
+#include "badger/math/random.h"
 
 namespace pathos {
 
@@ -66,7 +68,6 @@ namespace pathos {
 	static ConsoleVariable<int32> cvar_enable_ssr("r.ssr.enable", 1, "0 = disable SSR, 1 = enable SSR");
 	static ConsoleVariable<int32> cvar_enable_bloom("r.bloom", 1, "0 = disable bloom, 1 = enable bloom");
 	static ConsoleVariable<int32> cvar_enable_dof("r.dof.enable", 1, "0 = disable DoF, 1 = enable DoF");
-	static ConsoleVariable<int32> cvar_anti_aliasing("r.antialiasing.method", 1, "0 = disable, 1 = FXAA");
 
 	struct UBO_PerFrame {
 		matrix4               prevView; // For reprojection
@@ -79,6 +80,7 @@ namespace pathos {
 		matrix4               inverseProj;
 
 		vector4               projParams;
+		vector4               temporalJitter; // (x, y, ?, ?)
 		vector4               screenResolution; // (w, h, 1/w, 1/h)
 		vector4               zRange; // (near, far, fovYHalf_radians, aspectRatio(w/h))
 		vector4               time; // (currentTime, ?, ?, ?)
@@ -106,6 +108,14 @@ namespace pathos {
 		// ...
 
 		sceneRenderTargets.useGBuffer = true;
+
+		// [GDC2016] INSIDE uses 16 samples from Halton(2,3).
+		badger::HaltonSequence(2, JITTER_SEQ_LENGTH, temporalJitterSequenceX);
+		badger::HaltonSequence(3, JITTER_SEQ_LENGTH, temporalJitterSequenceY);
+		for (uint32 i = 0; i < JITTER_SEQ_LENGTH; ++i) {
+			temporalJitterSequenceX[i] = 2.0f * temporalJitterSequenceX[i] - 1.0f;
+			temporalJitterSequenceY[i] = 2.0f * temporalJitterSequenceY[i] - 1.0f;
+		}
 	}
 
 	SceneRenderer::~SceneRenderer() {
@@ -317,7 +327,7 @@ namespace pathos {
 			// #todo: Support nested gpu counters
 			SCOPED_GPU_COUNTER(PostProcessing);
 
-			const EAntiAliasingMethod antiAliasing = (EAntiAliasingMethod)badger::clamp(0, cvar_anti_aliasing.getInt(), (int32)EAntiAliasingMethod::NumMethods);
+			const EAntiAliasingMethod antiAliasing = getAntiAliasingMethod();
 			const ESuperResolutionMethod superResMethod = pathos::getSuperResolutionMethod();
 
 			enum class EPostProcessOrder : uint8 {
@@ -391,11 +401,12 @@ namespace pathos {
 
 			// Post Process: Anti-aliasing
 			switch (antiAliasing) {
-			case EAntiAliasingMethod::NoAA:
-				// Do nothing
-				break;
-
-			case EAntiAliasingMethod::FXAA:
+				case EAntiAliasingMethod::NoAA:
+				{
+					// Do nothing
+					break;
+				}
+				case EAntiAliasingMethod::FXAA:
 				{
 					const bool isFinalPP = isPPFinal(EPostProcessOrder::AntiAliasing);
 					const GLuint aaRenderTarget = isFinalPP ? sceneRenderTargets.sceneFinal : sceneRenderTargets.sceneColorAA;
@@ -405,11 +416,18 @@ namespace pathos {
 					fxaa->renderPostProcess(cmdList, fullscreenQuad.get());
 
 					sceneAfterLastPP = aaRenderTarget;
+					break;
 				}
-				break;
-
-			default:
-				break;
+				case EAntiAliasingMethod::TAA:
+				{
+					// #todo-taa
+					break;
+				}
+				default:
+				{
+					CHECK_NO_ENTRY();
+					break;
+				}
 			}
 
 			// Super resolution
@@ -681,6 +699,16 @@ namespace pathos {
 		data.inverseProj  = glm::inverse(projMatrix);
 
 		data.projParams  = vector4(1.0f / projMatrix[0][0], 1.0f / projMatrix[1][1], 0.0f, 0.0f);
+
+		if (getAntiAliasingMethod() == EAntiAliasingMethod::TAA) {
+			uint32 jitterIx = (scene->frameNumber) % JITTER_SEQ_LENGTH;
+			float K = getTemporalJitterMultiplier();
+			data.temporalJitter.x = K * temporalJitterSequenceX[jitterIx] / (float)sceneRenderTargets.sceneWidth;
+			data.temporalJitter.y = K * temporalJitterSequenceY[jitterIx] / (float)sceneRenderTargets.sceneHeight;
+			data.temporalJitter.z = data.temporalJitter.w = 0.0f;
+		} else {
+			data.temporalJitter = vector4(0.0f);
+		}
 
 		data.screenResolution.x = (float)sceneRenderTargets.sceneWidth;
 		data.screenResolution.y = (float)sceneRenderTargets.sceneHeight;

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
@@ -436,6 +436,7 @@ namespace pathos {
 					taa->setInput(EPostProcessInput::PPI_0, sceneAfterLastPP);
 					taa->setInput(EPostProcessInput::PPI_1, sceneRenderTargets.sceneColorHistory);
 					taa->setInput(EPostProcessInput::PPI_2, sceneRenderTargets.sceneDepth);
+					taa->setInput(EPostProcessInput::PPI_3, sceneRenderTargets.velocityMap);
 					taa->setOutput(EPostProcessOutput::PPO_0, aaRenderTarget);
 					taa->renderPostProcess(cmdList, fullscreenQuad.get());
 

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
@@ -174,13 +174,19 @@ namespace pathos {
 		}
 		// Do this everytime as reallocSceneTextures() might recreate GL textures.
 		{
-			GLenum gbuffer_draw_buffers[3] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2 };
+			GLenum gbuffer_draw_buffers[] = {
+				GL_COLOR_ATTACHMENT0,
+				GL_COLOR_ATTACHMENT1,
+				GL_COLOR_ATTACHMENT2,
+				GL_COLOR_ATTACHMENT3,
+			};
 			
 			cmdList.namedFramebufferTexture(gbufferFBO, GL_COLOR_ATTACHMENT0, sceneRenderTargets.gbufferA, 0);
 			cmdList.namedFramebufferTexture(gbufferFBO, GL_COLOR_ATTACHMENT1, sceneRenderTargets.gbufferB, 0);
 			cmdList.namedFramebufferTexture(gbufferFBO, GL_COLOR_ATTACHMENT2, sceneRenderTargets.gbufferC, 0);
+			cmdList.namedFramebufferTexture(gbufferFBO, GL_COLOR_ATTACHMENT3, sceneRenderTargets.velocityMap, 0);
 			cmdList.namedFramebufferTexture(gbufferFBO, GL_DEPTH_ATTACHMENT, sceneRenderTargets.sceneDepth, 0);
-			cmdList.namedFramebufferDrawBuffers(gbufferFBO, 3, gbuffer_draw_buffers);
+			cmdList.namedFramebufferDrawBuffers(gbufferFBO, _countof(gbuffer_draw_buffers), gbuffer_draw_buffers);
 
 			pathos::checkFramebufferStatus(cmdList, gbufferFBO, "gbuffer setup is invalid");
 		}
@@ -548,6 +554,7 @@ namespace pathos {
 		cmdList.clearNamedFramebufferuiv(gbufferFBO, GL_COLOR, 0, color_zero_ui);
 		cmdList.clearNamedFramebufferfv(gbufferFBO, GL_COLOR, 1, color_zero);
 		cmdList.clearNamedFramebufferfv(gbufferFBO, GL_COLOR, 2, color_zero);
+		cmdList.clearNamedFramebufferfv(gbufferFBO, GL_COLOR, 3, color_zero);
 		if (!bUseDepthPrepass) {
 			cmdList.clearNamedFramebufferfv(gbufferFBO, GL_DEPTH, 0, sceneDepthClearValue);
 		}
@@ -604,6 +611,7 @@ namespace pathos {
 				{
 					Material::UBO_PerObject uboData;
 					uboData.modelTransform = proxy->modelMatrix;
+					uboData.prevModelTransform = proxy->prevModelMatrix;
 					uboPerObject.update(cmdList, Material::UBO_PerObject::BINDING_POINT, &uboData);
 				}
 

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
@@ -732,6 +732,8 @@ namespace pathos {
 		if (getAntiAliasingMethod() == EAntiAliasingMethod::TAA) {
 			uint32 jitterIx = (scene->frameNumber) % JITTER_SEQ_LENGTH;
 			float K = getTemporalJitterMultiplier();
+			// It reduces the effectiveness of TAA, but also relax jittering when super resolution is enabled.
+			K /= getSuperResolutionScaleFactor();
 			data.temporalJitter.x = K * temporalJitterSequenceX[jitterIx] / (float)sceneRenderTargets.sceneWidth;
 			data.temporalJitter.y = K * temporalJitterSequenceY[jitterIx] / (float)sceneRenderTargets.sceneHeight;
 			data.temporalJitter.z = data.temporalJitter.w = 0.0f;

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.h
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.h
@@ -116,6 +116,9 @@ namespace pathos {
 		matrix4 prevView;
 		matrix4 prevInverseView;
 
+		static constexpr uint32 JITTER_SEQ_LENGTH = 16;
+		float temporalJitterSequenceX[JITTER_SEQ_LENGTH];
+		float temporalJitterSequenceY[JITTER_SEQ_LENGTH];
 	};
 
 }

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.h
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.h
@@ -64,6 +64,7 @@ namespace pathos {
 		static std::unique_ptr<class BloomPass>             bloomPass;
 		static std::unique_ptr<class ToneMapping>           toneMapping;
 		static std::unique_ptr<class FXAA>                  fxaa;
+		static uniquePtr<class TAA>                         taa;
 		static uniquePtr<class FSR1>                        fsr1;
 		static std::unique_ptr<class DepthOfField>          depthOfField;
 

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.h
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.h
@@ -116,6 +116,7 @@ namespace pathos {
 		Camera* camera;
 		matrix4 prevView;
 		matrix4 prevInverseView;
+		matrix4 prevViewProj;
 
 		static constexpr uint32 JITTER_SEQ_LENGTH = 16;
 		float temporalJitterSequenceX[JITTER_SEQ_LENGTH];

--- a/projects/PathosEngine/src/pathos/render/visualize_buffer.cpp
+++ b/projects/PathosEngine/src/pathos/render/visualize_buffer.cpp
@@ -35,7 +35,7 @@ namespace pathos {
 
 	static ConsoleVariable<int32> cvar_viewmode("r.viewmode", 0,
 		"0 = disable visualization, 1 = sceneDepth, 2 = albedo, 3 = worldNormal,\
-		 4 = metallic, 5 = roughness, 6 = emissive, 7 = ssao, 8 = ssr");
+		 4 = metallic, 5 = roughness, 6 = emissive, 7 = ssao, 8 = ssr, 9 = velocity");
 
 	VisualizeBufferPass::VisualizeBufferPass()
 		: dummyVAO(0)
@@ -83,6 +83,7 @@ namespace pathos {
 		cmdList.bindTextureUnit(3, sceneContext.gbufferC);
 		cmdList.bindTextureUnit(4, sceneContext.ssaoMap);
 		cmdList.bindTextureUnit(5, sceneContext.ssrRayTracing);
+		cmdList.bindTextureUnit(6, sceneContext.velocityMap);
 
 		cmdList.drawArrays(GL_TRIANGLE_STRIP, 0, 4);
 

--- a/projects/PathosEngine/src/pathos/text/text_component.cpp
+++ b/projects/PathosEngine/src/pathos/text/text_component.cpp
@@ -31,6 +31,7 @@ namespace pathos {
 		proxy->doubleSided = true;
 		proxy->renderInternal = false;
 		proxy->modelMatrix = getLocalMatrix() * invertTextY;
+		proxy->prevModelMatrix = proxy->modelMatrix; // #todo-motion-blur
 		proxy->geometry = geom.get();
 		proxy->material = material.get();
 		// #todo-frustum-culling: Update worldBounds for text component

--- a/shaders/Shaders.vcxproj
+++ b/shaders/Shaders.vcxproj
@@ -72,6 +72,7 @@
     <None Include="ssr_preintegration.glsl" />
     <None Include="ssr_raytracing.glsl" />
     <None Include="starfield.glsl" />
+    <None Include="temporal_anti_aliasing.glsl" />
     <None Include="tone_mapping.glsl" />
     <None Include="two_pass_gaussian_blur.glsl" />
     <None Include="visualize_buffer.glsl" />

--- a/shaders/Shaders.vcxproj.filters
+++ b/shaders/Shaders.vcxproj.filters
@@ -73,5 +73,6 @@
     <None Include="fsr1_wrapper_rcas.glsl" />
     <None Include="fsr1_wrapper_common.glsl" />
     <None Include="materials\gltf_opaque.glsl" />
+    <None Include="temporal_anti_aliasing.glsl" />
   </ItemGroup>
 </Project>

--- a/shaders/deferred_common.glsl
+++ b/shaders/deferred_common.glsl
@@ -90,6 +90,7 @@ layout (std140, binding = SLOT_UBO_PER_FRAME) uniform UBO_PerFrame {
 	mat4x4 inverseProjTransform;
 
 	vec4 projParams;
+	vec4 temporalJitter;
 	vec4 screenResolution; // (w, h, 1/w, 1/h)
 	vec4 zRange; // (near, far, fovYHalf_radians, aspectRatio(w/h))
 	vec4 time; // (currentTime, ?, ?, ?)

--- a/shaders/deferred_common.glsl
+++ b/shaders/deferred_common.glsl
@@ -80,14 +80,16 @@ float pointLightFalloff(float r, float d) {
 // #todo: Rename parameters to clarify view space and world space values.
 // Position components of camera and lights are in view space
 layout (std140, binding = SLOT_UBO_PER_FRAME) uniform UBO_PerFrame {
-	mat4x4 prevViewTransform; // For reprojection
-	mat4x4 prevInverseViewTransform; // For reprojection
 	mat4x4 viewTransform;
 	mat4x4 inverseViewTransform;
 	mat3x3 viewTransform3x3;
 	mat4x4 viewProjTransform;
 	mat4x4 projTransform;
 	mat4x4 inverseProjTransform;
+
+	mat4x4 prevViewTransform;
+	mat4x4 prevInverseViewTransform;
+	mat4x4 prevViewProjTransform;
 
 	vec4 projParams;
 	vec4 temporalJitter;

--- a/shaders/deferred_common_fs.glsl
+++ b/shaders/deferred_common_fs.glsl
@@ -18,6 +18,8 @@ layout (location = 1) out vec4 packOutput1;
 // w = <undefined>
 layout (location = 2) out uvec4 packOutput2;
 
+layout (location = 3) out vec2 outVelocityMap;
+
 // VS = view space
 void packGBuffer(
 	vec3 albedo, vec3 normalVS, uint materialID,

--- a/shaders/depth_prepass.glsl
+++ b/shaders/depth_prepass.glsl
@@ -2,9 +2,10 @@
 
 #include "deferred_common.glsl"
 
+// NOTE: Should match with what in _template.glsl
 layout (std140, binding = 1) uniform UBO_PerObject {
-	mat4 mvTransform;
-	mat3 mvTransform3x3;
+	mat4 modelTransform;
+	mat4 prevModelTransform;
 } uboPerObject;
 
 //////////////////////////////////////////////////////////////////////////
@@ -15,7 +16,7 @@ layout (location = 0) in vec3 position;
 layout (location = 1) in vec2 uv;
 
 void main() {
-	vec4 posWS = uboPerObject.mvTransform * vec4(position, 1.0);
+	vec4 posWS = uboPerObject.modelTransform * vec4(position, 1.0);
 	vec4 posCS = uboPerFrame.projTransform * posWS;
 
 	// Hmm... Wanted to integrate temporal jitter into the projection matrix,

--- a/shaders/depth_prepass.glsl
+++ b/shaders/depth_prepass.glsl
@@ -16,7 +16,13 @@ layout (location = 1) in vec2 uv;
 
 void main() {
 	vec4 posWS = uboPerObject.mvTransform * vec4(position, 1.0);
-	gl_Position = uboPerFrame.projTransform * posWS;
+	vec4 posCS = uboPerFrame.projTransform * posWS;
+
+	// Hmm... Wanted to integrate temporal jitter into the projection matrix,
+	// but no way I can know clipW a priori. Looks like this is the way.
+	posCS.xy += uboPerFrame.temporalJitter.xy * posCS.w;
+
+	gl_Position = posCS;
 }
 
 #endif

--- a/shaders/god_ray_silhouette.glsl
+++ b/shaders/god_ray_silhouette.glsl
@@ -19,7 +19,10 @@ void main() {
 
 	vec4 positionWS = model * vec4(inPosition, 1.0);
 
-	gl_Position = viewProj * positionWS;
+	vec4 positionCS = viewProj * positionWS;
+	positionCS.xy += uboPerFrame.temporalJitter.xy * positionCS.w;
+
+	gl_Position = positionCS;
 }
 
 #endif

--- a/shaders/materials/_template.glsl
+++ b/shaders/materials/_template.glsl
@@ -178,7 +178,9 @@ void main() {
 
 	// #todo: Precision issue.
 	// See SIGGRAPH2012 "Creating Vast Game Worlds" (p.11)
-	gl_Position = proj_view * positionWS;
+	vec4 positionCS = proj_view * positionWS;
+	positionCS.xy += uboPerFrame.temporalJitter.xy * positionCS.w;
+	gl_Position = positionCS;
 }
 
 #endif // VERTEX_SHADER

--- a/shaders/temporal_anti_aliasing.glsl
+++ b/shaders/temporal_anti_aliasing.glsl
@@ -15,6 +15,7 @@ layout (std140, binding = 1) uniform UBO_TAA {
 
 layout (binding = 0) uniform sampler2D inSceneColor;
 layout (binding = 1) uniform sampler2D inSceneColorHistory;
+layout (binding = 2) uniform sampler2D inSceneDepth;
 
 // --------------------------------------------------------
 // Output
@@ -26,9 +27,21 @@ layout (location = 0) out vec4 outSceneColor;
 
 void main() {
 	vec2 screenUV = fs_in.screenUV;
-	vec4 curr = texture(inSceneColor, screenUV);
-	vec4 prev = texture(inSceneColorHistory, screenUV);
 	float w = ubo.historyWeight;
 
-	outSceneColor = (1.0 - w) * curr + w * prev;
+	vec4 currColor = texture(inSceneColor, screenUV);
+	float currSceneDepth = texture(inSceneDepth, screenUV).r;
+	vec3 currWorldPos = getWorldPositionFromSceneDepth(screenUV, currSceneDepth);
+
+	vec4 prevClipPos = uboPerFrame.prevViewProjTransform * vec4(currWorldPos, 1.0);
+	vec2 prevScreenUV = 0.5 * (prevClipPos.xy / prevClipPos.w) + vec2(0.5, 0.5);
+
+	vec4 prevColor = currColor;
+	if (all(lessThanEqual(vec2(0.0, 0.0), prevScreenUV))
+		&& all(lessThan(prevScreenUV, vec2(1.0, 1.0))))
+	{
+		prevColor = texture(inSceneColorHistory, prevScreenUV);
+	}
+
+	outSceneColor = (1.0 - w) * currColor + w * prevColor;
 }

--- a/shaders/temporal_anti_aliasing.glsl
+++ b/shaders/temporal_anti_aliasing.glsl
@@ -16,6 +16,7 @@ layout (std140, binding = 1) uniform UBO_TAA {
 layout (binding = 0) uniform sampler2D inSceneColor;
 layout (binding = 1) uniform sampler2D inSceneColorHistory;
 layout (binding = 2) uniform sampler2D inSceneDepth;
+layout (binding = 3) uniform sampler2D inVelocityMap;
 
 // --------------------------------------------------------
 // Output
@@ -33,14 +34,43 @@ void main() {
 	float currSceneDepth = texture(inSceneDepth, screenUV).r;
 	vec3 currWorldPos = getWorldPositionFromSceneDepth(screenUV, currSceneDepth);
 
+	// #todo-taa: Sample velocityMap only for dynamic region.
+#if 0
 	vec4 prevClipPos = uboPerFrame.prevViewProjTransform * vec4(currWorldPos, 1.0);
 	vec2 prevScreenUV = 0.5 * (prevClipPos.xy / prevClipPos.w) + vec2(0.5, 0.5);
+#else
+	vec2 velocity = texture(inVelocityMap, screenUV).rg;
+	vec2 prevScreenUV = screenUV - velocity;
+#endif
 
 	vec4 prevColor = currColor;
 	if (all(lessThanEqual(vec2(0.0, 0.0), prevScreenUV))
 		&& all(lessThan(prevScreenUV, vec2(1.0, 1.0))))
 	{
+		// Neighborhood clamping
+		float dx = uboPerFrame.screenResolution.z;
+		float dy = uboPerFrame.screenResolution.w;
+		vec4 neighborMin = currColor;
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(-dx, -dy)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(0, -dy)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(dx, -dy)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(-dx, 0)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(dx, 0)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(-dx, dy)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(0, dy)));
+		neighborMin = min(neighborMin, texture(inSceneColor, screenUV + vec2(dx, dy)));
+		vec4 neighborMax = currColor;
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(-dx, -dy)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(0, -dy)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(dx, -dy)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(-dx, 0)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(dx, 0)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(-dx, dy)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(0, dy)));
+		neighborMax = max(neighborMax, texture(inSceneColor, screenUV + vec2(dx, dy)));
+
 		prevColor = texture(inSceneColorHistory, prevScreenUV);
+		prevColor = clamp(prevColor, neighborMin, neighborMax);
 	}
 
 	outSceneColor = (1.0 - w) * currColor + w * prevColor;

--- a/shaders/temporal_anti_aliasing.glsl
+++ b/shaders/temporal_anti_aliasing.glsl
@@ -1,0 +1,34 @@
+#version 460 core
+
+#include "deferred_common.glsl"
+
+// --------------------------------------------------------
+// Input
+
+in VS_OUT {
+	vec2 screenUV;
+} fs_in;
+
+layout (std140, binding = 1) uniform UBO_TAA {
+	float historyWeight;
+} ubo;
+
+layout (binding = 0) uniform sampler2D inSceneColor;
+layout (binding = 1) uniform sampler2D inSceneColorHistory;
+
+// --------------------------------------------------------
+// Output
+
+layout (location = 0) out vec4 outSceneColor;
+
+// --------------------------------------------------------
+// Shader
+
+void main() {
+	vec2 screenUV = fs_in.screenUV;
+	vec4 curr = texture(inSceneColor, screenUV);
+	vec4 prev = texture(inSceneColorHistory, screenUV);
+	float w = ubo.historyWeight;
+
+	outSceneColor = (1.0 - w) * curr + w * prev;
+}

--- a/shaders/visualize_buffer.glsl
+++ b/shaders/visualize_buffer.glsl
@@ -13,6 +13,7 @@
 #define VIEWMODE_EMISSIVE    6
 #define VIEWMODE_SSAO        7
 #define VIEWMODE_SSR         8
+#define VIEWMODE_VELOCITY    9
 
 in VS_OUT {
 	vec2 screenUV;
@@ -28,6 +29,7 @@ layout (binding = 2) uniform sampler2D gbuf1;
 layout (binding = 3) uniform usampler2D gbuf2;
 layout (binding = 4) uniform sampler2D ssaoMap;
 layout (binding = 5) uniform sampler2D ssr;
+layout (binding = 6) uniform sampler2D velocityMap;
 
 layout (location = 0) out vec4 outColor;
 
@@ -58,5 +60,8 @@ void main() {
 		outColor = vec4(vec3(ssao), 1.0);
 	} else if (viewmode == VIEWMODE_SSR) {
 		outColor = vec4(texture2D(ssr, screenUV).rgb, 1.0);
+	} else if (viewmode == VIEWMODE_VELOCITY) {
+		float fps = 144.0;
+		outColor = vec4(abs(texture2D(velocityMap, screenUV).rg) * fps, 0.0, 1.0);
 	}
 }


### PR DESCRIPTION
# Summary

Was going to implement HRAA in GPU Pro 6, but basic TAA was enough for current demo scenes.

References:
* SIGGRAPH 2014: HIGH-QUALITY TEMPORAL SUPERSAMPLING
* GDC 2016: Temporal Reprojection Anti Aliasing in INSIDE
* Eurographics 2020: A Survey of Temporal Antialiasing Techniques

Reserve HRAA for future until more advanced AA is needed.

# Sidenote for HRAA

GPU Pro 6: Hybrid Reconstruction Antialiasing

To implement HRAA, following GL extensions may be required:
* NV_explicit_multisample
* NV_sample_locations
* AMD_sample_positions

RTX 3080 Ti supports (1) and (2), Ryzen 6800U supports (1) and (3).