### PR TITLE
Scale everything to meters

### DIFF
--- a/Setup.ps1
+++ b/Setup.ps1
@@ -2,6 +2,9 @@
 # - Download and unzip large contents.
 # - Download and build third-party libraries.
 
+# Run this script with execution policy like this:
+# > powershell -ExecutionPolicy Bypass -File Setup.ps1
+
 #
 # Script arguments
 #
@@ -33,6 +36,11 @@ $contents_list  = @(
 		'https://casual-effects.com/g3d/data10/research/model/breakfast_room/breakfast_room.zip',
 		'breakfast_room.zip',
 		'breakfast_room'
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/sourceModels/RiggedFigure/RiggedFigure.dae',
+		'RiggedFigure.dae',
+		''
 	)
 )
 
@@ -103,7 +111,11 @@ if ($should_download) {
 		$zip_path = "$content_dir/$content_zip"
 		$unzip_path = "$content_dir/$content_unzip"
 		Download-URL $webclient $content_url $zip_path
-		Unzip $zip_path $unzip_path
+		
+		$file_ext = [IO.Path]::GetExtension($zip_path)
+		if ($file_ext -eq ".zip") {
+			Unzip $zip_path $unzip_path
+		}
 	}
 	
 	# TODO: How to close connection

--- a/Setup.ps1
+++ b/Setup.ps1
@@ -43,6 +43,11 @@ $contents_list  = @(
 		''
 	),
 	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/DamagedHelmet.bin',
+		'KhronosGroup/DamagedHelmet/DamagedHelmet.bin',
+		''
+	),
+	@(
 		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf',
 		'KhronosGroup/DamagedHelmet/DamagedHelmet.gltf',
 		''

--- a/Setup.ps1
+++ b/Setup.ps1
@@ -39,7 +39,37 @@ $contents_list  = @(
 	),
 	@(
 		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/sourceModels/RiggedFigure/RiggedFigure.dae',
-		'RiggedFigure.dae',
+		'KhronosGroup/RiggedFigure/RiggedFigure.dae',
+		''
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf',
+		'KhronosGroup/DamagedHelmet/DamagedHelmet.gltf',
+		''
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_AO.jpg',
+		'KhronosGroup/DamagedHelmet/Default_AO.jpg',
+		''
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_albedo.jpg',
+		'KhronosGroup/DamagedHelmet/Default_albedo.jpg',
+		''
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_emissive.jpg',
+		'KhronosGroup/DamagedHelmet/Default_emissive.jpg',
+		''
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg',
+		'KhronosGroup/DamagedHelmet/Default_metalRoughness.jpg',
+		''
+	),
+	@(
+		'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_normal.jpg',
+		'KhronosGroup/DamagedHelmet/Default_normal.jpg',
 		''
 	)
 )
@@ -110,6 +140,7 @@ if ($should_download) {
 		
 		$zip_path = "$content_dir/$content_zip"
 		$unzip_path = "$content_dir/$content_unzip"
+		Ensure-Subdirectory ([IO.Path]::GetDirectoryName($zip_path))
 		Download-URL $webclient $content_url $zip_path
 		
 		$file_ext = [IO.Path]::GetExtension($zip_path)

--- a/projects/PathosEngine/src/pathos/engine.cpp
+++ b/projects/PathosEngine/src/pathos/engine.cpp
@@ -35,7 +35,9 @@
 // Misc
 namespace pathos {
 
-	static ConsoleVariable<int32> maxFPS("t.maxFPS", 0, "Limit max framerate (0 = no limit)");
+	// #note: Setting this to 0 can make world delta seconds = 0.0
+	//        and the world will look like frozen.
+	static ConsoleVariable<int32> maxFPS("t.maxFPS", 1000, "Limit max framerate (0 = no limit)");
 
 	Engine*        gEngine  = nullptr;
 	ConsoleWindow* gConsole = nullptr;

--- a/projects/PathosEngine/src/pathos/engine_policy.h
+++ b/projects/PathosEngine/src/pathos/engine_policy.h
@@ -32,15 +32,4 @@ namespace pathos {
 		return (getReverseZPolicy() == EReverseZPolicy::Reverse) ? 1.0f : 0.0f;
 	}
 
-	namespace measurement {
-
-		// World unit distance is centimeter.
-		constexpr float  worldUnitToMeter(float unitDistance)  { return unitDistance * 100.0f; }
-		constexpr double worldUnitToMeter(double unitDistance) { return unitDistance * 100.0;  }
-
-		constexpr float  meterToWorldUnit(float meter)  { return meter * 0.01f; }
-		constexpr double meterToWorldUnit(double meter) { return meter * 0.01;  }
-
-	}
-
 }

--- a/projects/PathosEngine/src/pathos/engine_policy.h
+++ b/projects/PathosEngine/src/pathos/engine_policy.h
@@ -1,18 +1,23 @@
 #pragma once
 
-// WARNING: Minimize includes!!!
-//          Never include other than primitive types.
+// Configurations that globally affect the engine.
+// These policies should be constant in entire lifetime of the application.
+// Separated here to minimize #include dependencies.
+
+// WARNING: Minimize includes!!! Never include other than primitive types.
 #include <inttypes.h>
 
-// Configurations that globally affect the engine.
-// Separated here to minimize #include dependencies, but is this too random?
+// References:
+// 
+// [Reverse-Z]
+// https://developer.nvidia.com/content/depth-precision-visualized
+// https://nlguillemot.wordpress.com/2016/12/07/reversed-z-in-opengl/
+//
+// [Units of measurement]
+// https://seblagarde.wordpress.com/2015/07/14/siggraph-2014-moving-frostbite-to-physically-based-rendering/
 
 namespace pathos {
 
-	// - Reverse-Z policy should be constant in entire lifetime of the application.
-	// - References:
-	//   - https://developer.nvidia.com/content/depth-precision-visualized
-	//   - https://nlguillemot.wordpress.com/2016/12/07/reversed-z-in-opengl/
 	enum class EReverseZPolicy : uint8_t {
 		Traditional = 0,
 		Reverse = 1
@@ -25,6 +30,17 @@ namespace pathos {
 	}
 	constexpr float getDeviceNearDepth() {
 		return (getReverseZPolicy() == EReverseZPolicy::Reverse) ? 1.0f : 0.0f;
+	}
+
+	namespace measurement {
+
+		// World unit distance is centimeter.
+		constexpr float  worldUnitToMeter(float unitDistance)  { return unitDistance * 100.0f; }
+		constexpr double worldUnitToMeter(double unitDistance) { return unitDistance * 100.0;  }
+
+		constexpr float  meterToWorldUnit(float meter)  { return meter * 0.01f; }
+		constexpr double meterToWorldUnit(double meter) { return meter * 0.01;  }
+
 	}
 
 }

--- a/projects/PathosEngine/src/pathos/loader/imageloader.cpp
+++ b/projects/PathosEngine/src/pathos/loader/imageloader.cpp
@@ -84,7 +84,7 @@ namespace pathos {
 		std::string path = ResourceFinder::get().find(inFilename);
 		CHECK(path.size() != 0);
 
-		LOG(LogDebug, "load image: %s", path.c_str());
+		//LOG(LogDebug, "load image: %s", path.c_str());
 
 		FREE_IMAGE_FORMAT fif = FreeImage_GetFIFFromFilename(path.c_str());
 		FIBITMAP* dib = FreeImage_Load(fif, path.c_str(), 0);

--- a/projects/PathosEngine/src/pathos/loader/scene_desc_parser.cpp
+++ b/projects/PathosEngine/src/pathos/loader/scene_desc_parser.cpp
@@ -100,18 +100,18 @@ namespace pathos {
 		}
 
 		for (auto& [unused_key, L] : document[KEY_DIRECTIONAL_LIGHTS].items()) {
-			if (!checkMembers(L, { "name", "direction", "radiance" })) {
+			if (!checkMembers(L, { "name", "direction", "illuminance" })) {
 				continue;
 			}
 
 			std::string name(parseName(L));
 			vector3 dir = parseVec3(L["direction"]);
-			vector3 radiance = parseVec3(L["radiance"]);
+			vector3 illuminance = parseVec3(L["illuminance"]);
 
 			SceneDescription::DirLight desc;
 			desc.name = name;
 			desc.direction = glm::normalize(dir);
-			desc.radiance = radiance;
+			desc.illuminance = illuminance;
 
 			outDesc.dirLights.emplace_back(desc);
 		}
@@ -123,20 +123,20 @@ namespace pathos {
 		}
 
 		for (auto& [unused_key, L] : document[KEY_POINT_LIGHTS].items()) {
-			if (!checkMembers(L, { "name", "location", "radiance",
+			if (!checkMembers(L, { "name", "location", "intensity",
 					"attenuationRadius", "falloffExponent", "castsShadow" })) {
 				continue;
 			}
 
 			std::string name(parseName(L));
 			vector3 loc = parseVec3(L["location"]);
-			vector3 radiance = parseVec3(L["radiance"]);
+			vector3 intensity = parseVec3(L["intensity"]);
 			float attenuationR = L["attenuationRadius"];
 			float falloffExp = L["falloffExponent"];
 			bool castsShadow = L["castsShadow"];
 
 			SceneDescription::PointLight desc{
-				name, loc, radiance, attenuationR, falloffExp, castsShadow
+				name, loc, intensity, attenuationR, falloffExp, castsShadow
 			};
 			outDesc.pointLights.emplace_back(desc);
 		}

--- a/projects/PathosEngine/src/pathos/loader/scene_desc_parser.h
+++ b/projects/PathosEngine/src/pathos/loader/scene_desc_parser.h
@@ -31,12 +31,12 @@ namespace pathos {
 		struct DirLight {
 			std::string name;
 			vector3 direction;
-			vector3 radiance;
+			vector3 illuminance;
 		};
 		struct PointLight {
 			std::string name;
 			vector3 location;
-			vector3 radiance;
+			vector3 intensity;
 			float attenuationRadius;
 			float falloffExponent;
 			bool castsShadow;

--- a/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
+++ b/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
@@ -123,7 +123,8 @@ namespace pathos {
 		// directional lights
 		for (const SceneDescription::DirLight& dirLight : sceneDesc.dirLights) {
 			DirectionalLightActor* actor = world->spawnActor<DirectionalLightActor>();
-			actor->setLightParameters(dirLight.direction, dirLight.radiance);
+			actor->setDirection(dirLight.direction);
+			actor->setIlluminance(dirLight.radiance);
 
 			outActorMap.insert(std::make_pair(dirLight.name, actor));
 		}

--- a/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
+++ b/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
@@ -130,9 +130,10 @@ namespace pathos {
 		// point lights
 		for (const SceneDescription::PointLight& pLight : sceneDesc.pointLights) {
 			PointLightActor* actor = world->spawnActor<PointLightActor>();
-			// #todo-measurement: Use other setters + Rename 'radiance'
-			actor->setLightParameters(pLight.radiance, pLight.attenuationRadius,
-				pLight.falloffExponent, pLight.castsShadow);
+			actor->setIntensity(pLight.radiance);
+			actor->setAttenuationRadius(pLight.attenuationRadius);
+			actor->setFalloffExponent(pLight.falloffExponent);
+			actor->setCastsShadow(pLight.castsShadow);
 			actor->setActorLocation(pLight.location);
 
 			outActorMap.insert(std::make_pair(pLight.name, actor));

--- a/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
+++ b/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
@@ -124,14 +124,14 @@ namespace pathos {
 		for (const SceneDescription::DirLight& dirLight : sceneDesc.dirLights) {
 			DirectionalLightActor* actor = world->spawnActor<DirectionalLightActor>();
 			actor->setDirection(dirLight.direction);
-			actor->setIlluminance(dirLight.radiance);
+			actor->setIlluminance(dirLight.illuminance);
 
 			outActorMap.insert(std::make_pair(dirLight.name, actor));
 		}
 		// point lights
 		for (const SceneDescription::PointLight& pLight : sceneDesc.pointLights) {
 			PointLightActor* actor = world->spawnActor<PointLightActor>();
-			actor->setIntensity(pLight.radiance);
+			actor->setIntensity(pLight.intensity);
 			actor->setAttenuationRadius(pLight.attenuationRadius);
 			actor->setFalloffExponent(pLight.falloffExponent);
 			actor->setCastsShadow(pLight.castsShadow);

--- a/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
+++ b/projects/PathosEngine/src/pathos/loader/scene_loader.cpp
@@ -130,6 +130,7 @@ namespace pathos {
 		// point lights
 		for (const SceneDescription::PointLight& pLight : sceneDesc.pointLights) {
 			PointLightActor* actor = world->spawnActor<PointLightActor>();
+			// #todo-measurement: Use other setters + Rename 'radiance'
 			actor->setLightParameters(pLight.radiance, pLight.attenuationRadius,
 				pLight.falloffExponent, pLight.castsShadow);
 			actor->setActorLocation(pLight.location);

--- a/projects/PathosEngine/src/pathos/material/material.cpp
+++ b/projects/PathosEngine/src/pathos/material/material.cpp
@@ -110,7 +110,7 @@ namespace pathos {
 		if (normalTex != 0) {
 			M->setTextureParameter("normal", normalTex);
 		} else {
-			M->setTextureParameter("normal", gEngine->getSystemTexture2DBlue());
+			M->setTextureParameter("normal", gEngine->getSystemTexture2DNormalmap());
 			//M->setConstantParameter("normalOverride", vector3(0.0f, 0.0f, 1.0f));
 			//M->setConstantParameter("bOverrideNormal", true);
 		}

--- a/projects/PathosEngine/src/pathos/mesh/model_transform.h
+++ b/projects/PathosEngine/src/pathos/mesh/model_transform.h
@@ -29,7 +29,7 @@ namespace pathos {
 		const matrix4& getMatrix() const;
 
 	private:
-		vector3 location;
+		vector3 location; // Unit: meter
 		Rotator rotation;
 		vector3 scale;
 

--- a/projects/PathosEngine/src/pathos/render/shadow_directional.cpp
+++ b/projects/PathosEngine/src/pathos/render/shadow_directional.cpp
@@ -16,7 +16,7 @@
 namespace pathos {
 
 	// Light frustum could be too large if we use camera's zFar as is.
-	static ConsoleVariable<float> cvar_csm_zFar("r.csm.zFar", 5000.0f, "Custom zFar for CSM");
+	static ConsoleVariable<float> cvar_csm_zFar("r.csm.zFar", 50.0f, "Custom zFar for CSM");
 
 	struct UBO_CascadedShadowMap {
 		static constexpr uint32 BINDING_POINT = 1;

--- a/projects/PathosEngine/src/pathos/render/shadow_omni.cpp
+++ b/projects/PathosEngine/src/pathos/render/shadow_omni.cpp
@@ -117,8 +117,8 @@ namespace pathos {
 				continue;
 			}
 
-			constexpr float zNear = 0.1f;
-			const float zFar = badger::max(1.0f, light->attenuationRadius);
+			constexpr float zNear = 0.01f;
+			const float zFar = badger::max(zNear, light->attenuationRadius);
 			matrix4 projection = glm::perspective(glm::radians(90.0f), 1.0f, zNear, zFar);
 
 			PerspectiveLens shadowLens(90.0f, 1.0f, zNear, zFar);

--- a/projects/PathosEngine/src/pathos/render/volumetric_clouds.cpp
+++ b/projects/PathosEngine/src/pathos/render/volumetric_clouds.cpp
@@ -178,7 +178,7 @@ namespace pathos {
 			uboData.erosionNoiseScale = cvar_cloud_erosionNoiseScale.getFloat();
 
 			if (scene->proxyList_directionalLight.size() > 0) {
-				vector3 intensity = scene->proxyList_directionalLight[0]->radiance;
+				vector3 intensity = scene->proxyList_directionalLight[0]->illuminance;
 				intensity *= std::max(0.0f, cvar_cloud_sunIntensityScale.getFloat());
 				uboData.sunIntensity = vector4(intensity, 0.0f);
 				uboData.sunDirection = vector4(scene->proxyList_directionalLight[0]->wsDirection, 0.0f);

--- a/projects/PathosEngine/src/pathos/scene/directional_light_actor.h
+++ b/projects/PathosEngine/src/pathos/scene/directional_light_actor.h
@@ -14,7 +14,10 @@ namespace pathos {
 			setAsRootComponent(lightComponent);
 		}
 
-		// #todo-light: Temporary API
+		void setDirection(const vector3& direction) { lightComponent->direction = glm::normalize(direction); }
+		void setIlluminance(const vector3& illuminance) { lightComponent->radiance = illuminance; }
+
+		// #todo-measurement: Temporary API
 		void setLightParameters(
 			const vector3& inDirection,
 			const vector3& inRadiance)

--- a/projects/PathosEngine/src/pathos/scene/directional_light_actor.h
+++ b/projects/PathosEngine/src/pathos/scene/directional_light_actor.h
@@ -14,17 +14,8 @@ namespace pathos {
 			setAsRootComponent(lightComponent);
 		}
 
-		void setDirection(const vector3& direction) { lightComponent->direction = glm::normalize(direction); }
-		void setIlluminance(const vector3& illuminance) { lightComponent->radiance = illuminance; }
-
-		// #todo-measurement: Temporary API
-		void setLightParameters(
-			const vector3& inDirection,
-			const vector3& inRadiance)
-		{
-			lightComponent->direction = inDirection;
-			lightComponent->radiance = inRadiance;
-		}
+		void setDirection(const vector3& direction)     { lightComponent->direction = glm::normalize(direction); }
+		void setIlluminance(const vector3& illuminance) { lightComponent->illuminance = illuminance; }
 
 	private:
 		DirectionalLightComponent* lightComponent;

--- a/projects/PathosEngine/src/pathos/scene/directional_light_component.h
+++ b/projects/PathosEngine/src/pathos/scene/directional_light_component.h
@@ -7,7 +7,7 @@ namespace pathos {
 	struct DirectionalLightProxy : public SceneComponentProxy {
 		vector3 wsDirection;
 		float   padding0;
-		vector3 radiance;
+		vector3 illuminance;
 		float   padding1;
 		vector3 vsDirection;
 		float   padding2;
@@ -18,7 +18,7 @@ namespace pathos {
 	public:
 		DirectionalLightComponent()
 			: direction(vector3(0.0f, -1.0f, 0.0f))
-			, radiance(vector3(1.0f, 1.0f, 1.0f))
+			, illuminance(vector3(1.0f, 1.0f, 1.0f))
 		{}
 
 		virtual void createRenderProxy(SceneProxy* scene) override {
@@ -26,7 +26,7 @@ namespace pathos {
 
 			proxy->wsDirection = direction;
 			proxy->padding0    = 0.0f;
-			proxy->radiance    = radiance;
+			proxy->illuminance = illuminance;
 			proxy->padding1    = 0.0f;
 			proxy->vsDirection = vector3(0.0f); // This is filled later
 			proxy->padding2    = 0.0f;
@@ -36,7 +36,7 @@ namespace pathos {
 
 	public:
 		vector3 direction;
-		vector3 radiance; // #todo-measurement: Use illuminance.
+		vector3 illuminance; // Unit: lux (= lm/m^2 = lumen per square meter)
 
 	};
 

--- a/projects/PathosEngine/src/pathos/scene/directional_light_component.h
+++ b/projects/PathosEngine/src/pathos/scene/directional_light_component.h
@@ -36,7 +36,7 @@ namespace pathos {
 
 	public:
 		vector3 direction;
-		vector3 radiance;
+		vector3 radiance; // #todo-measurement: Use illuminance.
 
 	};
 

--- a/projects/PathosEngine/src/pathos/scene/point_light_actor.h
+++ b/projects/PathosEngine/src/pathos/scene/point_light_actor.h
@@ -21,19 +21,6 @@ namespace pathos {
 		void setCastsShadow(bool value)             { lightComponent->castsShadow = value; }
 		void setSourceRadius(float inRadius)        { lightComponent->sourceRadius = inRadius; }
 
-		// #todo-measurement: Temporary API
-		void setLightParameters(
-			const vector3& inIntensity = vector3(1.0f, 1.0f, 1.0f),
-			float inAttenuationRadius = 1.0f,
-			float inFalloffExponent = 0.001f,
-			bool castsShadow = true)
-		{
-			lightComponent->intensity = inIntensity;
-			lightComponent->attenuationRadius = inAttenuationRadius;
-			lightComponent->falloffExponent = inFalloffExponent;
-			lightComponent->castsShadow = castsShadow;
-		}
-
 		inline PointLightComponent* getLightComponent() const { return lightComponent; }
 
 	private:

--- a/projects/PathosEngine/src/pathos/scene/point_light_actor.h
+++ b/projects/PathosEngine/src/pathos/scene/point_light_actor.h
@@ -15,10 +15,16 @@ namespace pathos {
 			setAsRootComponent(lightComponent);
 		}
 
-		// #todo-light: Temporary API
+		void setIntensity(const vector3& intensity) { lightComponent->intensity = intensity; }
+		void setAttenuationRadius(float radius)     { lightComponent->attenuationRadius = radius; }
+		void setFalloffExponent(float exponent)     { lightComponent->falloffExponent = exponent; }
+		void setCastsShadow(bool value)             { lightComponent->castsShadow = value; }
+		void setSourceRadius(float inRadius)        { lightComponent->sourceRadius = inRadius; }
+
+		// #todo-measurement: Temporary API
 		void setLightParameters(
 			const vector3& inIntensity = vector3(1.0f, 1.0f, 1.0f),
-			float inAttenuationRadius = 100.0f,
+			float inAttenuationRadius = 1.0f,
 			float inFalloffExponent = 0.001f,
 			bool castsShadow = true)
 		{
@@ -26,10 +32,6 @@ namespace pathos {
 			lightComponent->attenuationRadius = inAttenuationRadius;
 			lightComponent->falloffExponent = inFalloffExponent;
 			lightComponent->castsShadow = castsShadow;
-		}
-
-		void setSourceRadius(float inRadius) {
-			lightComponent->sourceRadius = inRadius;
 		}
 
 		inline PointLightComponent* getLightComponent() const { return lightComponent; }

--- a/projects/PathosEngine/src/pathos/scene/point_light_component.h
+++ b/projects/PathosEngine/src/pathos/scene/point_light_component.h
@@ -22,7 +22,7 @@ namespace pathos {
 		
 	public:
 		PointLightComponent()
-			: intensity(vector3(100.0f, 100.0f, 100.0f))
+			: intensity(vector3(10.0f, 10.0f, 10.0f))
 			, attenuationRadius(1.0f)
 			, falloffExponent(0.001f)
 			, castsShadow(true)
@@ -46,11 +46,11 @@ namespace pathos {
 		}
 
 	public:
-		vector3   intensity;         // #todo-measurement: Photometric unit (maybe candela)
-		float     attenuationRadius; // in meters
+		vector3   intensity;         // Unit: candela = lm/sr = luminuous intensity
+		float     attenuationRadius; // Unit: meter
 		float     falloffExponent;
 		bool      castsShadow;
-		float     sourceRadius;      // in meters
+		float     sourceRadius;      // Unit: meter
 
 	};
 

--- a/projects/PathosEngine/src/pathos/scene/point_light_component.h
+++ b/projects/PathosEngine/src/pathos/scene/point_light_component.h
@@ -23,10 +23,10 @@ namespace pathos {
 	public:
 		PointLightComponent()
 			: intensity(vector3(100.0f, 100.0f, 100.0f))
-			, attenuationRadius(100.0f)
+			, attenuationRadius(1.0f)
 			, falloffExponent(0.001f)
 			, castsShadow(true)
-			, sourceRadius(1.0f)
+			, sourceRadius(0.01f)
 		{
 		}
 
@@ -46,11 +46,11 @@ namespace pathos {
 		}
 
 	public:
-		vector3   intensity;
-		float     attenuationRadius;
+		vector3   intensity;         // #todo-measurement: Photometric unit (maybe candela)
+		float     attenuationRadius; // in meters
 		float     falloffExponent;
 		bool      castsShadow;
-		float     sourceRadius;
+		float     sourceRadius;      // in meters
 
 	};
 

--- a/projects/PathosEngine/src/pathos/scene/scene_capture_component.h
+++ b/projects/PathosEngine/src/pathos/scene/scene_capture_component.h
@@ -22,7 +22,7 @@ namespace pathos {
 
 	public:
 		float fovY = 60.0f; // in degrees
-		float zNear = 1.0f;
+		float zNear = 0.01f;
 		float zFar = 10000.0f;
 		RenderTarget2D* renderTarget = nullptr;
 		bool captureHDR = true; // Ignored if render target has depth format.

--- a/projects/PathosEngine/src/pathos/scene/static_mesh_component.cpp
+++ b/projects/PathosEngine/src/pathos/scene/static_mesh_component.cpp
@@ -72,7 +72,7 @@ namespace pathos {
 
 	AABB StaticMeshComponent::getWorldBounds() const
 	{
-		AABB total;
+		AABB total = AABB::fromMinMax(vector3(0.0f), vector3(0.0f));
 		auto& geoms = mesh->getGeometries();
 		if (geoms.size() > 0) {
 			total = calculateWorldBounds(geoms[0]->getLocalBounds(), getLocalMatrix());

--- a/projects/PathosEngine/src/pathos/scene/world.cpp
+++ b/projects/PathosEngine/src/pathos/scene/world.cpp
@@ -8,7 +8,7 @@
 namespace pathos {
 
 	World::World()
-		: camera(PerspectiveLens(60.0f, 16.0f / 9.0f, 0.1f, 100000.0f))
+		: camera(PerspectiveLens(60.0f, 16.0f / 9.0f, 0.01f, 100000.0f))
 		, inputManager(nullptr)
 	{
 		scene.owner = this;

--- a/projects/Test_DeferredRenderer/src/lightning_effect.cpp
+++ b/projects/Test_DeferredRenderer/src/lightning_effect.cpp
@@ -10,7 +10,7 @@
 #include "badger/math/random.h"
 
 static const vector3 LIGHTNING_PARTICLE_EMISSIVE(10.0f, 10.0f, 25.0f);
-static const float LIGHTNING_PARTICLE_THICKNESS = 80.0f;
+static const float LIGHTNING_PARTICLE_THICKNESS = 0.8f;
 
 #define LIGHTNING_MASK_TEXTURE  "resources/render_challenge_1/lightning_mask.jpg"
 #define LIGHTNING_WARP_TEXTURE  "resources/render_challenge_1/lightning_warp.jpg"

--- a/projects/Test_DeferredRenderer/src/main.cpp
+++ b/projects/Test_DeferredRenderer/src/main.cpp
@@ -14,7 +14,7 @@ const int32 WINDOW_HEIGHT        = 1080;
 const bool  WINDOW_FULLSCREEN    = false;
 
 void changeWorld() {
-	static const int32 numWorlds = 3;
+	static const int32 numWorlds = 4;
 	static int32 worldIndex = 0;
 
 	World* newWorld = nullptr;
@@ -31,13 +31,9 @@ void changeWorld() {
 		newWorld = new World_LightRoom;
 		gEngine->getMainWindow()->setTitle("Light Room");
 		break;
-	// #todo-gltf
-	//case 3:
-	//	newWorld = new World_Sponza;
-	//	gEngine->getMainWindow()->setTitle("Yet another Sponza");
-	//	break;
 	case 3:
-		// More worlds here...
+		newWorld = new World_Sponza;
+		gEngine->getMainWindow()->setTitle("Yet another Sponza");
 		break;
 	default:
 		CHECK_NO_ENTRY();

--- a/projects/Test_DeferredRenderer/src/player_controller.cpp
+++ b/projects/Test_DeferredRenderer/src/player_controller.cpp
@@ -24,19 +24,18 @@ void PlayerController::onTick(float deltaSeconds)
 	int32 currMouseX = input->getMouseX();
 	int32 currMouseY = input->getMouseY();
 
-	// movement per seconds
 	const float moveMultiplier = badger::max(1.0f, input->getAxis("moveFast") * 10.0f);
-	const float speedRight = 200.0f * deltaSeconds * moveMultiplier;
-	const float speedForward = 200.0f * deltaSeconds * moveMultiplier;
-	const float speedUp = 200.0f * deltaSeconds * moveMultiplier;
-	const float rotateYaw = 120.0f * deltaSeconds;
-	const float rotatePitch = 120.0f * deltaSeconds;
+	float moveRight    = deltaSeconds * (speedRight * moveMultiplier);
+	float moveForward  = deltaSeconds * (speedForward * moveMultiplier);
+	float moveUp       = deltaSeconds * (speedUp * moveMultiplier);
+	float rotateYaw    = deltaSeconds * speedYaw;
+	float rotatePitch  = deltaSeconds * speedPitch;
 
-	float deltaRight = input->getAxis("moveRight") * speedRight;
-	float deltaForward = input->getAxis("moveForward") * speedForward;
-	float deltaUp = input->getAxis("moveUp") * speedUp;
-	float rotY = 0.1f * (currMouseX - prevMouseX) * rotateYaw;
-	float rotX = 0.1f * (currMouseY - prevMouseY) * rotatePitch;
+	float deltaRight   = input->getAxis("moveRight")   * moveRight;
+	float deltaForward = input->getAxis("moveForward") * moveForward;
+	float deltaUp      = input->getAxis("moveUp")      * moveUp;
+	float rotY         = 0.1f * (currMouseX - prevMouseX) * rotateYaw;
+	float rotX         = 0.1f * (currMouseY - prevMouseY) * rotatePitch;
 
 	camera.moveForward(deltaForward);
 	camera.moveRight(deltaRight);

--- a/projects/Test_DeferredRenderer/src/player_controller.h
+++ b/projects/Test_DeferredRenderer/src/player_controller.h
@@ -10,6 +10,15 @@ public:
 	virtual void onSpawn() override;
 	virtual void onTick(float deltaSeconds) override;
 
+	// movement (meters/sec)
+	float speedRight   = 2.0f;
+	float speedForward = 2.0f;
+	float speedUp      = 2.0f;
+
+	// rotation (degrees/sec)
+	float speedYaw    = 120.0f;
+	float speedPitch  = 120.0f;
+
 private:
 	void setupInput();
 

--- a/projects/Test_DeferredRenderer/src/transform_test_actor.cpp
+++ b/projects/Test_DeferredRenderer/src/transform_test_actor.cpp
@@ -4,8 +4,8 @@
 #include "pathos/mesh/geometry_primitive.h"
 #include "pathos/mesh/mesh.h"
 
-static const float height = 40.0f;
-static const float radius = 50.0f;
+static const float height = 0.4f;
+static const float radius = 0.5f;
 static const int32 numStars = 7;
 
 TransformTestActor::TransformTestActor()
@@ -19,18 +19,18 @@ TransformTestActor::TransformTestActor()
 	M_base->setConstantParameter("roughness", 0.9f);
 	M_base->setConstantParameter("emissive", vector3(0.0f, 0.0f, 0.0f));
 
-	MeshGeometry* rootG = new SphereGeometry(10.0f);
+	MeshGeometry* rootG = new SphereGeometry(0.1f);
 	Material* rootM = Material::createMaterialInstance("solid_color");
 	rootM->copyParametersFrom(M_base);
 	rootM->setConstantParameter("roughness", 0.35f);
 	root->setStaticMesh(new Mesh(rootG, rootM));
 
-	MeshGeometry* starG = new CubeGeometry(vector3(10.0f, 10.0f, 10.0f));
+	MeshGeometry* starG = new CubeGeometry(vector3(0.1f, 0.1f, 0.1f));
 	Material* starM = Material::createMaterialInstance("solid_color");
 	starM->copyParametersFrom(M_base);
 	starM->setConstantParameter("emissive", vector3(1.0f, 1.0f, 5.0f));
 
-	MeshGeometry* moonG = new CubeGeometry(vector3(3.0f, 3.0f, 3.0f));
+	MeshGeometry* moonG = new CubeGeometry(vector3(0.03f, 0.03f, 0.03f));
 	Material* moonM = Material::createMaterialInstance("solid_color");
 	moonM->copyParametersFrom(M_base);
 	moonM->setConstantParameter("albedo", vector3(0.9f, 0.9f, 0.1f));
@@ -75,6 +75,6 @@ void TransformTestActor::onTick(float deltaSeconds) {
 
 		float angle = (2.0f * 3.141592f) * (float)i / numStars;
 		angle += worldTime * 3.0f;
-		moon->setLocation(vector3(0.0f, 25.0f * std::cos(angle), 25.0f * std::sin(angle)));
+		moon->setLocation(vector3(0.0f, 0.25f * std::cos(angle), 0.25f * std::sin(angle)));
 	}
 }

--- a/projects/Test_DeferredRenderer/src/world1.cpp
+++ b/projects/Test_DeferredRenderer/src/world1.cpp
@@ -45,16 +45,16 @@ std::vector<WavefrontModelDesc> wavefrontModels = {
 	{
 		"models/fireplace_room/fireplace_room.obj",
 		"models/fireplace_room/",
-		vector3(600.0f, -10.0f, 0.0f),
+		vector3(6.0f, 0.0f, 0.0f),
 		Rotator(-90.0f, 0.0f, 0.0f),
-		vector3(50.0f)
+		vector3(0.5f)
 	},
 	{
 		"breakfast_room/breakfast_room.obj",
 		"breakfast_room/",
-		vector3(-100.0f, -10.0f, 50.0f),
+		vector3(-1.0f, 0.2f, 0.5f),
 		Rotator(90.0f, 0.0f, 0.0f),
-		vector3(30.0f)
+		vector3(0.3f)
 	},
 };
 
@@ -179,9 +179,6 @@ void World1::setupScene()
 	// --------------------------------------------------------
 	// Create materials
 
-	GLuint tex = pathos::createTextureFromBitmap(loadImage("resources/textures/154.jpg"), true, true);
-	GLuint tex_norm = pathos::createTextureFromBitmap(loadImage("resources/textures/154_norm.jpg"), true, false);
-
 	Material* material_color = Material::createMaterialInstance("solid_color");
 	material_color->setConstantParameter("albedo", vector3(0.9f, 0.2f, 0.2f));
 	material_color->setConstantParameter("metallic", 0.0f);
@@ -191,7 +188,7 @@ void World1::setupScene()
 	Material* material_mirrorGround = Material::createMaterialInstance("solid_color");
 	material_mirrorGround->setConstantParameter("albedo", vector3(0.9f, 0.9f, 0.9f));
 	material_mirrorGround->setConstantParameter("metallic", 0.0f);
-	material_mirrorGround->setConstantParameter("roughness", 0.0f);
+	material_mirrorGround->setConstantParameter("roughness", 0.1f);
 	material_mirrorGround->setConstantParameter("emissive", vector3(0.0f));
 
 	// PBR material
@@ -222,11 +219,11 @@ void World1::setupScene()
 	// --------------------------------------------------------
 	// Create geometries
 
-	auto geom_sphere_big = new SphereGeometry(15.0f, 30);
-	auto geom_sphere = new SphereGeometry(5.0f, 30);
-	auto geom_plane = new PlaneGeometry(10.0f, 10.0f);
-	auto geom_plane_big = new PlaneGeometry(10.0f, 10.0f, 20, 20);
-	auto geom_cube = new CubeGeometry(vector3(5.0f));
+	auto geom_sphere_big = new SphereGeometry(0.15f, 30);
+	auto geom_sphere = new SphereGeometry(0.05f, 30);
+	auto geom_sceneCapture = new PlaneGeometry(1.0f, 1.0f);
+	auto geom_ground = new PlaneGeometry(100.0f, 100.0f, 4, 4);
+	auto geom_cube = new CubeGeometry(vector3(0.05f));
 
 	// --------------------------------------------------------
 	// Lighting
@@ -239,20 +236,20 @@ void World1::setupScene()
 	PointLightActor* pointLight2 = spawnActor<PointLightActor>();
 	PointLightActor* pointLight3 = spawnActor<PointLightActor>();
 
-	pointLight0->setActorLocation(vector3(-50.0f + 700.0f, 60.0f, 170.0f));
-	pointLight1->setActorLocation(vector3(0.0f + 700.0f, 30.0f, 150.0f));
-	pointLight2->setActorLocation(vector3(-20.0f + 700.0f, 50.0f, 50.0f));
-	pointLight3->setActorLocation(vector3(-20.0f + 700.0f, 50.0f, 150.0f));
+	pointLight0->setActorLocation(vector3(-0.5f + 7.0f, 0.6f, 1.7f));
+	pointLight1->setActorLocation(vector3(00.0f + 7.0f, 0.3f, 1.5f));
+	pointLight2->setActorLocation(vector3(-0.2f + 7.0f, 0.5f, 0.5f));
+	pointLight3->setActorLocation(vector3(-0.2f + 7.0f, 0.5f, 1.5f));
 
-	pointLight0->setLightParameters(50000.0f * vector3(0.2f, 2.0f, 1.0f), 100.0f, 0.001f, true);
-	pointLight1->setLightParameters(30000.0f * vector3(2.0f, 0.2f, 1.0f), 100.0f, 0.001f, true);
-	pointLight2->setLightParameters(50000.0f * vector3(2.0f, 0.0f, 0.0f), 150.0f, 0.001f, true);
-	pointLight3->setLightParameters(20000.0f * vector3(2.0f, 2.0f, 2.0f), 200.0f, 0.0001f, true);
+	pointLight0->setLightParameters(5.0f * vector3(0.2f, 2.0f, 1.0f), 1.0f, 0.001f, true);
+	pointLight1->setLightParameters(3.0f * vector3(2.0f, 0.2f, 1.0f), 1.0f, 0.001f, true);
+	pointLight2->setLightParameters(5.0f * vector3(2.0f, 0.0f, 0.0f), 1.5f, 0.001f, true);
+	pointLight3->setLightParameters(2.0f * vector3(2.0f, 2.0f, 2.0f), 2.0f, 0.0001f, true);
 
 	godRaySource = spawnActor<StaticMeshActor>();
 	godRaySource->setStaticMesh(new Mesh(geom_sphere, material_color));
 	godRaySource->setActorScale(20.0f);
-	godRaySource->setActorLocation(vector3(0.0f, 500.0f, -1500.0f));
+	godRaySource->setActorLocation(vector3(0.0f, 5.0f, -15.0f));
 	godRaySource->getStaticMeshComponent()->castsShadow = false;
 	getScene().godRaySource = godRaySource->getStaticMeshComponent();
 
@@ -260,20 +257,19 @@ void World1::setupScene()
 	// Static meshes
 
 	ground = spawnActor<StaticMeshActor>();
-	ground->setStaticMesh(new Mesh(geom_plane_big, material_mirrorGround));
-	ground->setActorScale(1000.0f);
+	ground->setStaticMesh(new Mesh(geom_ground, material_mirrorGround));
 	ground->setActorRotation(Rotator(0.0f, -90.0f, 0.0f));
-	ground->setActorLocation(vector3(0.0f, -30.0f, 0.0f));
+	ground->setActorLocation(vector3(0.0f, -0.3f, 0.0f));
 	ground->getStaticMeshComponent()->castsShadow = false;
 
 	transformTestActor = spawnActor<TransformTestActor>();
-	transformTestActor->setActorLocation(vector3(-800.0f, 50.0f, 100.0f));
+	transformTestActor->setActorLocation(vector3(-8.0f, 0.5f, 1.0f));
 
 	for (uint32 i = 0u; i < NUM_BALLS; ++i) {
 		StaticMeshActor* ball = spawnActor<StaticMeshActor>();
 		ball->setStaticMesh(new Mesh(geom_sphere, material_pbr));
 		ball->setActorScale(5.0f + (float)i * 0.5f);
-		ball->setActorLocation(vector3(-400.0f, 50.0f, 300.0f - 100.0f * i));
+		ball->setActorLocation(vector3(-4.0f, 0.5f, 3.0f - 1.0f * i));
 		balls.push_back(ball);
 	}
 	for (uint32 i = 0u; i < NUM_BALLS; ++i) {
@@ -286,14 +282,14 @@ void World1::setupScene()
 		StaticMeshActor* ball = spawnActor<StaticMeshActor>();
 		ball->setStaticMesh(new Mesh(geom_cube, ball_material));
 		ball->setActorScale(5.0f + (float)i * 0.5f);
-		ball->setActorLocation(vector3(-550.0f, 50.0f, 300.0f - 100.0f * i));
+		ball->setActorLocation(vector3(-5.5f, 0.5f, 3.0f - 1.0f * i));
 		balls.push_back(ball);
 	}
 
-	constexpr float box_x0 = 250.0f;
-	constexpr float box_y0 = 60.0f;
-	constexpr float box_spaceX = 20.0f;
-	constexpr float box_spaceY = 20.0f;
+	constexpr float box_x0 = 2.5f;
+	constexpr float box_y0 = 0.6f;
+	constexpr float box_spaceX = 0.2f;
+	constexpr float box_spaceY = 0.2f;
 	float sinT = 0.0f;
 	Material* box_material = Material::createMaterialInstance("solid_color");
 
@@ -309,7 +305,7 @@ void World1::setupScene()
 
 			StaticMeshActor* box = spawnActor<StaticMeshActor>();
 			box->setStaticMesh(new Mesh(geom_cube, box_material));
-			box->setActorLocation(vector3(box_x0 + i * box_spaceX, 50.0f, box_y0 + j * box_spaceY));
+			box->setActorLocation(vector3(box_x0 + i * box_spaceX, 0.5f, box_y0 + j * box_spaceY));
 			box->setActorScale(vector3(1.0f, 10.0f * 0.5f * (1.0f + wave), 1.0f));
 
 			//if (i == 0 && j == 0) {
@@ -343,9 +339,9 @@ void World1::setupScene()
 	material_sceneCapture->setTextureParameter("inputTexture", tempRenderTarget->getGLName());
 	
 	StaticMeshActor* sceneCaptureViewer = spawnActor<StaticMeshActor>();
-	sceneCaptureViewer->setStaticMesh(new Mesh(geom_plane, material_sceneCapture));
-	sceneCaptureViewer->setActorLocation(-500.0f, 300.0f, -300.0f);
-	sceneCaptureViewer->setActorScale(3.0f * vector3(16.0f, 9.0f, 1.0f));
+	sceneCaptureViewer->setStaticMesh(new Mesh(geom_sceneCapture, material_sceneCapture));
+	sceneCaptureViewer->setActorLocation(-5.0f, 3.0f, -3.0f);
+	sceneCaptureViewer->setActorScale(0.1f * vector3(16.0f, 9.0f, 1.0f));
 
 	// --------------------------------------------------------
 	// Bloom test
@@ -355,7 +351,7 @@ void World1::setupScene()
 	material_tooBright->setConstantParameter("roughness", 1.0f);
 	material_tooBright->setConstantParameter("emissive", vector3(100.0f, 0.0f, 0.0f));
 	StaticMeshActor* bloomActor = spawnActor<StaticMeshActor>();
-	bloomActor->setActorLocation(200.0f, 80.0f, 600.0f);
+	bloomActor->setActorLocation(2.0f, 0.8f, 6.0f);
 	bloomActor->setActorScale(20.0f);
 	bloomActor->setStaticMesh(new Mesh(geom_sphere, material_tooBright));
 }
@@ -399,7 +395,7 @@ void World1::onTick(float deltaSeconds)
 	static float ballAngle = 0.0f;
 	for (StaticMeshActor* ball : balls) {
 		Rotator rot = ball->getActorRotation();
-		rot.yaw = fmod(rot.yaw + 1.0f, 180.0f);
+		rot.yaw = fmod(rot.yaw + 1.0f, 360.0f);
 		ball->setActorRotation(rot);
 	}
 

--- a/projects/Test_DeferredRenderer/src/world1.cpp
+++ b/projects/Test_DeferredRenderer/src/world1.cpp
@@ -18,10 +18,10 @@
 // --------------------------------------------------------
 // Constants
 
-static const vector3 CAMERA_POSITION      = vector3(20.0f, 25.0f, 200.0f);
-static const vector3 CAMERA_LOOK_AT       = vector3(20.0f, 25.0f, 190.0f);
+static const vector3 CAMERA_POSITION      = vector3(0.0f, 1.0f, 2.0f);
+static const vector3 CAMERA_LOOK_AT       = vector3(0.0f, 1.0f, 0.0f);
 static const vector3 SUN_DIRECTION        = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
-static const vector3 SUN_RADIANCE         = 1.2f * vector3(1.0f, 1.0f, 1.0f);
+static const vector3 SUN_ILLUMINANCE      = 1.2f * vector3(1.0f, 1.0f, 1.0f);
 
 #define              SKY_METHOD           2
 static const char*   SKY_HDRI             = "resources/skybox/HDRI/Ridgecrest_Road_Ref.hdr";
@@ -231,7 +231,8 @@ void World1::setupScene()
 	// --------------------------------------------------------
 	// Lighting
 	DirectionalLightActor* dirLight = spawnActor<DirectionalLightActor>();
-	dirLight->setLightParameters(SUN_DIRECTION, SUN_RADIANCE);
+	dirLight->setDirection(SUN_DIRECTION);
+	dirLight->setIlluminance(SUN_ILLUMINANCE);
 
 	PointLightActor* pointLight0 = spawnActor<PointLightActor>();
 	PointLightActor* pointLight1 = spawnActor<PointLightActor>();

--- a/projects/Test_DeferredRenderer/src/world1.cpp
+++ b/projects/Test_DeferredRenderer/src/world1.cpp
@@ -241,10 +241,17 @@ void World1::setupScene()
 	pointLight2->setActorLocation(vector3(-0.2f + 7.0f, 0.5f, 0.5f));
 	pointLight3->setActorLocation(vector3(-0.2f + 7.0f, 0.5f, 1.5f));
 
-	pointLight0->setLightParameters(5.0f * vector3(0.2f, 2.0f, 1.0f), 1.0f, 0.001f, true);
-	pointLight1->setLightParameters(3.0f * vector3(2.0f, 0.2f, 1.0f), 1.0f, 0.001f, true);
-	pointLight2->setLightParameters(5.0f * vector3(2.0f, 0.0f, 0.0f), 1.5f, 0.001f, true);
-	pointLight3->setLightParameters(2.0f * vector3(2.0f, 2.0f, 2.0f), 2.0f, 0.0001f, true);
+	pointLight0->setIntensity(5.0f * vector3(0.2f, 2.0f, 1.0f));
+	pointLight0->setAttenuationRadius(1.0f);
+
+	pointLight1->setIntensity(4.0f * vector3(0.1f, 0.1f, 1.0f));
+	pointLight1->setAttenuationRadius(1.0f);
+
+	pointLight2->setIntensity(10.0f * vector3(1.0f, 0.0f, 0.0f));
+	pointLight2->setAttenuationRadius(1.5f);
+
+	pointLight3->setIntensity(3.0f * vector3(1.0f, 1.0f, 1.0f));
+	pointLight3->setAttenuationRadius(2.0f);
 
 	godRaySource = spawnActor<StaticMeshActor>();
 	godRaySource->setStaticMesh(new Mesh(geom_sphere, material_color));

--- a/projects/Test_DeferredRenderer/src/world_lightroom.cpp
+++ b/projects/Test_DeferredRenderer/src/world_lightroom.cpp
@@ -22,8 +22,8 @@
 // --------------------------------------------------------
 // Constants
 
-static const vector3 CAMERA_POSITION    = vector3(70.0f, 60.0f, 250.0f);
-static const vector3 CAMERA_LOOK_AT     = vector3(0.0f, 10.0f, 0.0f);
+static const vector3 CAMERA_POSITION    = vector3(0.7f, 0.6f, 2.5f);
+static const vector3 CAMERA_LOOK_AT     = vector3(0.0f, 0.1f, 0.0f);
 static const vector3 SUN_DIRECTION      = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
 static const vector3 SUN_RADIANCE       = 0.05f * vector3(1.0f, 1.0f, 1.0f);
 
@@ -39,15 +39,15 @@ void World_LightRoom::onInitialize() {
 void World_LightRoom::onTick(float deltaSeconds) {
 	if (TEST_RECT_LIGHT) {
 		float t = gEngine->getWorldTime() * 1.57f;
-		float w = 25.0f + 10.0f * cosf(t);
-		float h = 15.0f + 5.0f * sinf(t);
+		float w = 0.01f * (25.0f + 10.0f * cosf(t));
+		float h = 0.01f * (15.0f + 5.0f * sinf(t));
 		rectLight0->setLightSize(w, h);
-		rectLight0Gizmo->setActorScale(vector3(1.0f, h / 15.0f, w / 25.0f));
+		rectLight0Gizmo->setActorScale(vector3(1.0f, h / 0.15f, w / 0.25f));
 	}
 
 	if (TEST_POINT_LIGHT) {
 		float k = 0.5f * (1.0f + cosf(gEngine->getWorldTime()));
-		float radii = 1.0f + k * (10.0f - 1.0f);
+		float radii = 0.01f + k * (0.1f - 0.01f);
 		pointLight0->setSourceRadius(radii);
 		pointLight0Gizmo->setActorScale(radii);
 	}
@@ -61,7 +61,7 @@ void World_LightRoom::setupScene() {
 	// --------------------------------------------------------
 	// Ground & walls
 
-	MeshGeometry* G_ground = new PlaneGeometry(1000.0f, 1000.0f, 10, 10);
+	MeshGeometry* G_ground = new PlaneGeometry(10.0f, 10.0f, 10, 10);
 
 #if 1
 	Material* M_ground = Material::createMaterialInstance("solid_color");
@@ -91,16 +91,16 @@ void World_LightRoom::setupScene() {
 
 	wallA = TEMP_SPAWN_ACTOR(StaticMeshActor);
 	wallA->setStaticMesh(mesh_wall);
-	wallA->setActorLocation(0.0f, 0.0f, -30.0f);
+	wallA->setActorLocation(0.0f, 0.0f, -0.3f);
 	wallB = TEMP_SPAWN_ACTOR(StaticMeshActor);
 	wallB->setStaticMesh(mesh_wall);
-	wallB->setActorLocation(-30.0f, 0.0f, 0.0f);
+	wallB->setActorLocation(-0.3f, 0.0f, 0.0f);
 	wallB->setActorRotation(Rotator(90.0f, 0.0f, 0.0f));
 
 	// --------------------------------------------------------
 	// Box
 
-	const float boxHalfSize = 10.0f;
+	const float boxHalfSize = 0.1f;
 
 	MeshGeometry* G_box = new CubeGeometry(vector3(boxHalfSize));
 	MeshGeometry* G_ball = new SphereGeometry(boxHalfSize);
@@ -119,11 +119,11 @@ void World_LightRoom::setupScene() {
 
 	box = TEMP_SPAWN_ACTOR(StaticMeshActor);
 	box->setStaticMesh(new Mesh(G_box, M_box));
-	box->setActorLocation(0.0f, boxHalfSize, 50.0f);
+	box->setActorLocation(0.0f, boxHalfSize, 0.5f);
 
 	ball = TEMP_SPAWN_ACTOR(StaticMeshActor);
 	ball->setStaticMesh(new Mesh(G_ball, M_ball));
-	ball->setActorLocation(100.0f, boxHalfSize, 50.0f);
+	ball->setActorLocation(1.0f, boxHalfSize, 0.5f);
 
 	// --------------------------------------------------------
 	// Lights
@@ -133,8 +133,9 @@ void World_LightRoom::setupScene() {
 
 #if TEST_POINT_LIGHT
 	pointLight0 = TEMP_SPAWN_ACTOR(PointLightActor);
-	pointLight0->setActorLocation(100.0f + boxHalfSize * 1.5f, boxHalfSize * 3.0f, 0.0f);
-	pointLight0->setLightParameters(500.0f * vector3(1.0f, 1.0f, 1.0f), 70.0f);
+	pointLight0->setActorLocation(1.0f + boxHalfSize * 1.5f, boxHalfSize * 3.0f, 0.0f);
+	pointLight0->setIntensity(10.0f * vector3(1.0f, 1.0f, 1.0f));
+	pointLight0->setAttenuationRadius(0.7f);
 
 	MeshGeometry* G_pointLightGizmo = new SphereGeometry(1.0f);
 	Material* M_pointLightGizmo = Material::createMaterialInstance("solid_color");
@@ -150,11 +151,11 @@ void World_LightRoom::setupScene() {
 
 #if TEST_RECT_LIGHT
 	rectLight0 = TEMP_SPAWN_ACTOR(RectLightActor);
-	rectLight0->setActorLocation(boxHalfSize * 1.5f, boxHalfSize * 2.5f, -10.0f);
+	rectLight0->setActorLocation(boxHalfSize * 1.5f, boxHalfSize * 2.5f, -0.1f);
 	rectLight0->setActorRotation(Rotator(-120.0f, 0.0f, -20.0f));
-	rectLight0->setLightSize(25.0f, 15.0f);
-	rectLight0->setLightIntensity(3000.0f * vector3(1.0f, 1.0f, 1.0f));
-	rectLight0->setAttenuationRadius(300.0f);
+	rectLight0->setLightSize(0.25f, 0.15f);
+	rectLight0->setLightIntensity(30.0f * vector3(1.0f, 1.0f, 1.0f));
+	rectLight0->setAttenuationRadius(3.0f);
 
 	MeshGeometry* G_rectLightGizmo = new PlaneGeometry(
 		rectLight0->getLightComponent()->width,
@@ -168,7 +169,7 @@ void World_LightRoom::setupScene() {
 	rectLight0Gizmo->setStaticMesh(new Mesh(G_rectLightGizmo, M_rectLightGizmo));
 	rectLight0Gizmo->getStaticMeshComponent()->castsShadow = false;
 	vector3 rectForward = rectLight0->getActorRotation().toDirection();
-	rectLight0Gizmo->setActorLocation(rectLight0->getActorLocation() - rectForward);
+	rectLight0Gizmo->setActorLocation(rectLight0->getActorLocation() - (0.01f * rectForward));
 	rectLight0Gizmo->setActorRotation(rectLight0->getActorRotation());
 #endif
 }

--- a/projects/Test_DeferredRenderer/src/world_lightroom.cpp
+++ b/projects/Test_DeferredRenderer/src/world_lightroom.cpp
@@ -25,7 +25,7 @@
 static const vector3 CAMERA_POSITION    = vector3(0.7f, 0.6f, 2.5f);
 static const vector3 CAMERA_LOOK_AT     = vector3(0.0f, 0.1f, 0.0f);
 static const vector3 SUN_DIRECTION      = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
-static const vector3 SUN_RADIANCE       = 0.05f * vector3(1.0f, 1.0f, 1.0f);
+static const vector3 SUN_ILLUMINANCE    = 0.05f * vector3(1.0f, 1.0f, 1.0f);
 
 // --------------------------------------------------------
 // World
@@ -129,7 +129,8 @@ void World_LightRoom::setupScene() {
 	// Lights
 
 	sun = TEMP_SPAWN_ACTOR(DirectionalLightActor);
-	sun->setLightParameters(SUN_DIRECTION, SUN_RADIANCE);
+	sun->setDirection(SUN_DIRECTION);
+	sun->setIlluminance(SUN_ILLUMINANCE);
 
 #if TEST_POINT_LIGHT
 	pointLight0 = TEMP_SPAWN_ACTOR(PointLightActor);

--- a/projects/Test_DeferredRenderer/src/world_rc1.cpp
+++ b/projects/Test_DeferredRenderer/src/world_rc1.cpp
@@ -52,8 +52,8 @@
 #define STARFIELD_HEIGHT         2048
 #define STARFIELD_CUBEMAP_SIZE   512
 
-static const vector3             CAMERA_POSITION = vector3(20.0f, 25.0f, 200.0f);
-static const vector3             CAMERA_LOOK_AT  = vector3(20.0f, 25.0f, 190.0f);
+static const vector3             CAMERA_POSITION = vector3(0.2f, 0.25f, 2.0f);
+static const vector3             CAMERA_LOOK_AT  = vector3(0.2f, 0.25f, 1.9f);
 static const vector3             SUN_DIRECTION   = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
 static const vector3             SUN_ILLUMINANCE = 1.0f * vector3(1.0f, 1.0f, 1.0f);
 static constexpr float           Y_OFFSET        = 5000.0f; // Offset every actor to match with cloud layer
@@ -71,8 +71,8 @@ void World_RC1::onInitialize()
 	gEngine->getAssetStreamer()->enqueueWavefrontOBJ(assetRefGuardTower, this, &World_RC1::onLoadOBJ, 0);
 	
 	spaceship1 = spawnActor<SpaceshipActor>();
-	spaceship1->setActorScale(30.0f);
-	spaceship1->setActorLocation(vector3(-347.0f, Y_OFFSET - 1098.0f, 1648.0f));
+	spaceship1->setActorScale(0.3f);
+	spaceship1->setActorLocation(vector3(-3.47f, Y_OFFSET - 10.98f, 16.48f));
 	spaceship1->setActorRotation(Rotator(92.91f, 41.14f, 0.0f));
 	{
 		SplineLoader loader;
@@ -82,8 +82,8 @@ void World_RC1::onInitialize()
 		spaceship1->setSpline(std::move(spline1));
 	}
 	spaceship2 = spawnActor<SpaceshipActor>();
-	spaceship2->setActorScale(30.0f);
-	spaceship2->setActorLocation(vector3(1257.0f, Y_OFFSET - 1098.0f, 348.0f));
+	spaceship2->setActorScale(0.3f);
+	spaceship2->setActorLocation(vector3(12.57f, Y_OFFSET - 10.98f, 3.48f));
 	spaceship2->setActorRotation(Rotator(112.91f, -21.14f, 0.0f));
 	{
 		SplineLoader loader;
@@ -100,7 +100,7 @@ void World_RC1::onInitialize()
 	setupScene();
 
 	getCamera().lookAt(CAMERA_POSITION, CAMERA_LOOK_AT, vector3(0.0f, 1.0f, 0.0f));
-	getCamera().moveToPosition(0.0f, Y_OFFSET - 100.0f, 4000.0f);
+	getCamera().moveToPosition(0.0f, Y_OFFSET - 1.0f, 40.0f);
 
 	// --------------------------------------------------------
 	// Setup input
@@ -165,7 +165,7 @@ void World_RC1::onTick(float deltaSeconds)
 		//vector3 splineLocation = spline.locationAtTime(sampleTime);
 		//vector3 splineTangent  = glm::normalize(spline.tangentAtTime(sampleTime));
 
-		ModelTransform transform(vector3(-347.0f, Y_OFFSET - 1098.0f, 1648.0f), Rotator(), vector3(1000.0f));
+		ModelTransform transform(vector3(-3.47f, Y_OFFSET - 10.98f, 16.48f), Rotator(), vector3(10.0f));
 		splineLocation = vector3(transform.getMatrix() * vector4(splineLocation, 1.0f));
 
 		spaceship1->setActorLocation(splineLocation);
@@ -193,7 +193,7 @@ void World_RC1::onTick(float deltaSeconds)
 		//vector3 splineLocation = spline.locationAtTime(sampleTime);
 		//vector3 splineTangent  = glm::normalize(spline.tangentAtTime(sampleTime));
 
-		ModelTransform transform(vector3(-2347.0f, Y_OFFSET - 1098.0f, 1648.0f), Rotator(), vector3(1000.0f));
+		ModelTransform transform(vector3(-23.47f, Y_OFFSET - 10.98f, 16.48f), Rotator(), vector3(10.0f));
 		splineLocation = vector3(transform.getMatrix() * vector4(splineLocation, 1.0f));
 
 		spaceship2->setActorLocation(splineLocation);
@@ -259,8 +259,9 @@ void World_RC1::setupScene()
 
 	PointLightActor* pointLight = spawnActor<PointLightActor>();
 	pointLight->setActorLocation(0.0f, Y_OFFSET, 0.0f);
-	pointLight->setLightParameters(5000000.0f * vector3(1.0f, 1.0f, 1.0f), 10000.0f);
-	pointLight->setSourceRadius(40.0f);
+	pointLight->setIntensity(1000.0f * vector3(1.0f, 1.0f, 1.0f));
+	pointLight->setAttenuationRadius(50.0f);
+	pointLight->setSourceRadius(0.4f);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Materials
@@ -285,14 +286,14 @@ void World_RC1::setupScene()
 	// Objects
 
 	lightningSphere = spawnActor<LightningActor>();
-	lightningSphere->setActorScale(40.0f);
+	lightningSphere->setActorScale(0.4f);
 	lightningSphere->setActorLocation(pointLight->getActorLocation());
 
 	constexpr uint32 numRings = 6;
-	const float ring_gap = 40.0f;
-	const float ring_width = 100.0f;
-	const float ring_thickness = 50.0f;
-	float innerRadius = 150.0f;
+	const float ring_gap = 0.4f;
+	const float ring_width = 1.0f;
+	const float ring_thickness = 0.5f;
+	float innerRadius = 1.5f;
 	float outerRadius = innerRadius + ring_width;
 	std::vector<std::vector<float>> ringSegRanges = {
 		{0.0f, 280.0f},
@@ -304,9 +305,9 @@ void World_RC1::setupScene()
 	};
 	for (uint32 i = 0; i < numRings; ++i) {
 		auto ring = spawnActor<RingActor>();
-		ring->buildRing(innerRadius, outerRadius, ring_thickness + (i * 20.0f), ringSegRanges[i]);
+		ring->buildRing(innerRadius, outerRadius, ring_thickness + (i * 0.2f), ringSegRanges[i]);
 		innerRadius = outerRadius + ring_gap;
-		outerRadius = innerRadius + (ring_width + i * 50.0f);
+		outerRadius = innerRadius + (ring_width + i * 0.55f);
 		rings.push_back(ring);
 
 		ring->setActorLocation(0.0f, Y_OFFSET, 0.0f);
@@ -334,8 +335,8 @@ void World_RC1::onLoadOBJ(OBJLoader* loader, uint64 payload)
 
 	guardTower = spawnActor<StaticMeshActor>();
 	guardTower->setStaticMesh(loader->craftMeshFromAllShapes());
-	guardTower->setActorScale(1000.0f);
-	guardTower->setActorLocation(vector3(0.0f, Y_OFFSET - 4700.0f, 0.0f));
+	guardTower->setActorScale(10.0f);
+	guardTower->setActorLocation(vector3(0.0f, Y_OFFSET - 47.0f, 0.0f));
 
 	M_tower->setTextureParameter("albedo", loader->findGLTexture("T_Tower.png"));
 	M_tower->setTextureParameter("normal", loader->findGLTexture("N_Tower.png"));

--- a/projects/Test_DeferredRenderer/src/world_rc1.cpp
+++ b/projects/Test_DeferredRenderer/src/world_rc1.cpp
@@ -55,7 +55,7 @@
 static const vector3             CAMERA_POSITION = vector3(20.0f, 25.0f, 200.0f);
 static const vector3             CAMERA_LOOK_AT  = vector3(20.0f, 25.0f, 190.0f);
 static const vector3             SUN_DIRECTION   = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
-static const vector3             SUN_RADIANCE    = 1.0f * vector3(1.0f, 1.0f, 1.0f);
+static const vector3             SUN_ILLUMINANCE = 1.0f * vector3(1.0f, 1.0f, 1.0f);
 static constexpr float           Y_OFFSET        = 5000.0f; // Offset every actor to match with cloud layer
 
 // --------------------------------------------------------
@@ -254,7 +254,8 @@ void World_RC1::setupScene()
 	//////////////////////////////////////////////////////////////////////////
 	// Light
 	DirectionalLightActor* dirLight = spawnActor<DirectionalLightActor>();
-	dirLight->setLightParameters(SUN_DIRECTION, SUN_RADIANCE);
+	dirLight->setDirection(SUN_DIRECTION);
+	dirLight->setIlluminance(SUN_ILLUMINANCE);
 
 	PointLightActor* pointLight = spawnActor<PointLightActor>();
 	pointLight->setActorLocation(0.0f, Y_OFFSET, 0.0f);

--- a/projects/Test_DeferredRenderer/src/world_sponza.cpp
+++ b/projects/Test_DeferredRenderer/src/world_sponza.cpp
@@ -25,24 +25,24 @@
 // Configuration
 #define GLTF_TESTCASE 1
 #define SKYLIGHT      1
-#define POINTLIGHT    0
+#define POINTLIGHT    1
 
-// #todo-gltf: Download these GLTF assets via Setup.ps1
+// #todo-gltf: Intel Sponza is way too big (a few gigabytes) to include in the download list.
 #if GLTF_TESTCASE == 0
 	#define GLTF_FILENAME "intel_sponza/Main.1_Sponza/NewSponza_Main_glTF_002.gltf"
-	#define GLTF_SCALE_MULT 100.0f
+	#define GLTF_SCALE_MULT 1.0f
 	#define GLTF_ROT Rotator(0.0f, 0.0f, 0.0f)
 #elif GLTF_TESTCASE == 1
-	#define GLTF_FILENAME "damaged_helmet/DamagedHelmet.gltf"
-	#define GLTF_SCALE_MULT 100.0f
+	#define GLTF_FILENAME "resources_external/KhronosGroup/DamagedHelmet/DamagedHelmet.gltf"
+	#define GLTF_SCALE_MULT 1.0f
 	#define GLTF_ROT Rotator(0.0f, -90.0f, 0.0f)
 #endif
 
 // --------------------------------------------------------
 // Constants
 
-static const vector3 CAMERA_POSITION    = vector3(70.0f, 60.0f, 250.0f);
-static const vector3 CAMERA_LOOK_AT     = vector3(0.0f, 10.0f, 0.0f);
+static const vector3 CAMERA_POSITION    = vector3(0.7f, 0.6f, 2.5f);
+static const vector3 CAMERA_LOOK_AT     = vector3(0.0f, 0.1f, 0.0f);
 static const vector3 SUN_DIRECTION      = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
 static const vector3 SUN_ILLUMINANCE    = 5.0f * vector3(1.0f, 1.0f, 1.0f);
 
@@ -87,7 +87,7 @@ void World_Sponza::setupScene() {
 	// --------------------------------------------------------
 	// Ground
 
-	MeshGeometry* G_ground = new PlaneGeometry(1000.0f, 1000.0f, 10, 10);
+	MeshGeometry* G_ground = new PlaneGeometry(100.0f, 100.0f, 10, 10);
 
 	Material* M_ground = Material::createMaterialInstance("solid_color");
 	M_ground->setConstantParameter("albedo", vector3(0.33f, 0.22f, 0.18f)); // brown
@@ -95,15 +95,18 @@ void World_Sponza::setupScene() {
 	M_ground->setConstantParameter("metallic", 0.0f);
 	M_ground->setConstantParameter("emissive", vector3(0.0f));
 
-	//ground = TEMP_SPAWN_ACTOR(StaticMeshActor);
-	//ground->setStaticMesh(new Mesh(G_ground, M_ground));
-	//ground->setActorLocation(0.0f, 0.0f, 0.0f);
-	//ground->setActorRotation(Rotator(0.0f, -90.0f, 0.0f));
+#if GLTF_TESTCASE == 1
+	ground = TEMP_SPAWN_ACTOR(StaticMeshActor);
+	ground->setStaticMesh(new Mesh(G_ground, M_ground));
+	ground->getStaticMesh()->doubleSided = true;
+	ground->setActorLocation(0.0f, -1.0f, 0.0f);
+	ground->setActorRotation(Rotator(0.0f, -90.0f, 0.0f));
+#endif
 
 	textActor = spawnActor<TextMeshActor>();
 	textActor->setText(L"Loading GLTF asset...");
 	textActor->setColor(1.0f, 0.0f, 0.0f);
-	textActor->setActorScale(300.0f);
+	textActor->setActorScale(3.0f);
 
 	// --------------------------------------------------------
 	// Lights
@@ -114,14 +117,14 @@ void World_Sponza::setupScene() {
 
 #if POINTLIGHT
 	PointLightActor* pointLight0 = TEMP_SPAWN_ACTOR(PointLightActor);
-	pointLight0->setActorLocation(600.0f, 150.0f, 0.0f);
-	pointLight0->setIntensity(500000.0f * vector3(1.0f, 0.5f, 0.5f));
-	pointLight0->setAttenuationRadius(1000.0f);
+	pointLight0->setActorLocation(6.0f, 1.5f, 0.0f);
+	pointLight0->setIntensity(5000.0f * vector3(1.0f, 0.5f, 0.5f));
+	pointLight0->setAttenuationRadius(10.0f);
 
 	PointLightActor* pointLight1 = TEMP_SPAWN_ACTOR(PointLightActor);
-	pointLight1->setActorLocation(-600.0f, 150.0f, 0.0f);
-	pointLight1->setIntensity(500000.0f * vector3(0.5f, 0.5f, 1.0f));
-	pointLight1->setAttenuationRadius(1000.0f);
+	pointLight1->setActorLocation(-6.0f, 1.5f, 0.0f);
+	pointLight1->setIntensity(5000.0f * vector3(0.5f, 0.5f, 1.0f));
+	pointLight1->setAttenuationRadius(10.0f);
 #endif
 
 	// --------------------------------------------------------

--- a/projects/Test_DeferredRenderer/src/world_sponza.cpp
+++ b/projects/Test_DeferredRenderer/src/world_sponza.cpp
@@ -44,7 +44,7 @@
 static const vector3 CAMERA_POSITION    = vector3(70.0f, 60.0f, 250.0f);
 static const vector3 CAMERA_LOOK_AT     = vector3(0.0f, 10.0f, 0.0f);
 static const vector3 SUN_DIRECTION      = glm::normalize(vector3(0.0f, -1.0f, -1.0f));
-static const vector3 SUN_RADIANCE       = 5.0f * vector3(1.0f, 1.0f, 1.0f);
+static const vector3 SUN_ILLUMINANCE    = 5.0f * vector3(1.0f, 1.0f, 1.0f);
 
 // --------------------------------------------------------
 // World
@@ -109,7 +109,8 @@ void World_Sponza::setupScene() {
 	// Lights
 
 	sun = TEMP_SPAWN_ACTOR(DirectionalLightActor);
-	sun->setLightParameters(SUN_DIRECTION, SUN_RADIANCE);
+	sun->setDirection(SUN_DIRECTION);
+	sun->setIlluminance(SUN_ILLUMINANCE);
 
 #if POINTLIGHT
 	PointLightActor* pointLight0 = TEMP_SPAWN_ACTOR(PointLightActor);

--- a/projects/Test_DeferredRenderer/src/world_sponza.cpp
+++ b/projects/Test_DeferredRenderer/src/world_sponza.cpp
@@ -115,11 +115,13 @@ void World_Sponza::setupScene() {
 #if POINTLIGHT
 	PointLightActor* pointLight0 = TEMP_SPAWN_ACTOR(PointLightActor);
 	pointLight0->setActorLocation(600.0f, 150.0f, 0.0f);
-	pointLight0->setLightParameters(500000.0f * vector3(1.0f, 0.5f, 0.5f), 1000.0f);
+	pointLight0->setIntensity(500000.0f * vector3(1.0f, 0.5f, 0.5f));
+	pointLight0->setAttenuationRadius(1000.0f);
 
 	PointLightActor* pointLight1 = TEMP_SPAWN_ACTOR(PointLightActor);
 	pointLight1->setActorLocation(-600.0f, 150.0f, 0.0f);
-	pointLight1->setLightParameters(500000.0f * vector3(0.5f, 0.5f, 1.0f), 1000.0f);
+	pointLight1->setIntensity(500000.0f * vector3(0.5f, 0.5f, 1.0f));
+	pointLight1->setAttenuationRadius(1000.0f);
 #endif
 
 	// --------------------------------------------------------

--- a/projects/Test_RacingGame/src/main.cpp
+++ b/projects/Test_RacingGame/src/main.cpp
@@ -6,9 +6,6 @@ const char*         WINDOW_TITLE = "Test: Racing Game";
 const int32         WINDOW_WIDTH = 1920;
 const int32         WINDOW_HEIGHT = 1080;
 const bool          WINDOW_FULLSCREEN = false;
-const float         FOVY = 60.0f;
-const float         CAMERA_Z_NEAR = 1.0f;
-const float         CAMERA_Z_FAR = 5000.0f;
 
 #define WORLD_CLASS World_Game1
 
@@ -20,11 +17,7 @@ int main(int argc, char** argv) {
 	conf.title = WINDOW_TITLE;
 	Engine::init(argc, argv, conf);
 
-	const float aspect_ratio = static_cast<float>(conf.windowWidth) / static_cast<float>(conf.windowHeight);
-
 	World* world1 = new WORLD_CLASS;
-	world1->getCamera().lookAt(CAMERA_POSITION, CAMERA_LOOK_AT, vector3(0.0f, 1.0f, 0.0f));
-	world1->getCamera().changeLens(PerspectiveLens(FOVY, aspect_ratio, CAMERA_Z_NEAR, CAMERA_Z_FAR));
 	
 	gEngine->setWorld(world1);
 	gEngine->start();

--- a/projects/Test_RacingGame/src/player_controller.cpp
+++ b/projects/Test_RacingGame/src/player_controller.cpp
@@ -85,7 +85,7 @@ void PlayerController::tickGameplay(float deltaSeconds)
 	Camera& camera = getWorld()->getCamera();
 	InputManager* input = getWorld()->getInputManager();
 
-	float powerForward = input->getAxis("moveForward") * 500.0f;
+	float powerForward = input->getAxis("moveForward") * 50.0f;
 	float powerTurn = input->getAxis("moveRight") * 50.0f;
 
 	vector3 forwardDir = pawnRotation.toDirection();
@@ -108,11 +108,10 @@ void PlayerController::tickGameplay(float deltaSeconds)
 	playerPawn->setActorLocation(pawnLoc);
 	playerPawn->setActorRotation(pawnRotation);
 
-	const float CAMERA_HEIGHT_OFFSET = 40.0f;
 	vector3 cameraLoc = pawnLoc;
-	cameraLoc -= forwardDir * 200.0f;
-	cameraLoc.y += CAMERA_HEIGHT_OFFSET;
-	camera.lookAt(cameraLoc, pawnLoc + vector3(0.0f, CAMERA_HEIGHT_OFFSET, 0.0f), vector3(0.0f, 1.0f, 0.0f));
+	cameraLoc -= forwardDir * cameraForwardOffset;
+	cameraLoc.y += cameraHeightOffset;
+	camera.lookAt(cameraLoc, pawnLoc + vector3(0.0f, cameraHeightOffset, 0.0f), vector3(0.0f, 1.0f, 0.0f));
 }
 
 void PlayerController::tickPhotoMode(float deltaSeconds)
@@ -127,17 +126,17 @@ void PlayerController::tickPhotoMode(float deltaSeconds)
 
 	// movement per seconds
 	const float moveMultiplier = badger::max(1.0f, input->getAxis("moveFast") * 10.0f);
-	const float speedRight = 200.0f * deltaSeconds * moveMultiplier;
-	const float speedForward = 200.0f * deltaSeconds * moveMultiplier;
-	const float speedUp = 200.0f * deltaSeconds * moveMultiplier;
-	const float rotateYaw = 120.0f * deltaSeconds;
-	const float rotatePitch = 120.0f * deltaSeconds;
+	const float speedRight   = 2.0f * deltaSeconds * moveMultiplier;
+	const float speedForward = 2.0f * deltaSeconds * moveMultiplier;
+	const float speedUp      = 2.0f * deltaSeconds * moveMultiplier;
+	const float rotateYaw    = 120.0f * deltaSeconds;
+	const float rotatePitch  = 120.0f * deltaSeconds;
 
-	float deltaRight = input->getAxis("moveRight") * speedRight;
+	float deltaRight   = input->getAxis("moveRight") * speedRight;
 	float deltaForward = input->getAxis("moveForward") * speedForward;
-	float deltaUp = input->getAxis("moveUp") * speedUp;
-	float rotY = 0.1f * (currMouseX - prevMouseX) * rotateYaw;
-	float rotX = 0.1f * (currMouseY - prevMouseY) * rotatePitch;
+	float deltaUp      = input->getAxis("moveUp") * speedUp;
+	float rotY         = 0.1f * (currMouseX - prevMouseX) * rotateYaw;
+	float rotX         = 0.1f * (currMouseY - prevMouseY) * rotatePitch;
 
 	camera.moveForward(deltaForward);
 	camera.moveRight(deltaRight);

--- a/projects/Test_RacingGame/src/player_controller.h
+++ b/projects/Test_RacingGame/src/player_controller.h
@@ -13,6 +13,9 @@ public:
 	void setPlayerPawn(Actor* player);
 	void togglePhotoMode();
 
+	float cameraHeightOffset  = 1.8f;
+	float cameraForwardOffset = 3.0f;
+
 private:
 	void setupInput();
 	void tickGameplay(float deltaSeconds);

--- a/projects/Test_RacingGame/src/world_game1.cpp
+++ b/projects/Test_RacingGame/src/world_game1.cpp
@@ -13,14 +13,18 @@
 #include "pathos/loader/scene_loader.h"
 #include "pathos/input/input_manager.h"
 
-#define SCENE_DESC_FILE "resources/racing_game/test_scene.json"
+#define SCENE_DESC_FILE          "resources/racing_game/test_scene.json"
+#define LANDSCAPE_ALBEDO_MAP     "resources/racing_game/landscape.jpg"
 
-#define CLOUD_WEATHER_MAP_FILE   "racing_game/WeatherMap.png"
-#define CLOUD_SHAPE_NOISE_FILE   "common/noiseShapePacked.tga"
-#define CLOUD_EROSION_NOISE_FILE "common/noiseErosionPacked.tga"
+#define CLOUD_WEATHER_MAP_FILE   "resources/racing_game/WeatherMap.png"
+#define CLOUD_SHAPE_NOISE_FILE   "resources/common/noiseShapePacked.tga"
+#define CLOUD_EROSION_NOISE_FILE "resources/common/noiseErosionPacked.tga"
 
-const vector3 CAMERA_POSITION = vector3(0.0f, 0.0f, 50.0f);
+const vector3 CAMERA_POSITION = vector3(0.0f, 0.0f, 0.5f);
 const vector3 CAMERA_LOOK_AT  = vector3(0.0f, 0.0f, 0.0f);
+
+const float   PLAYERCAM_HEIGHT_OFFSET  = 2.8f;
+const float   PLAYERCAM_FORWARD_OFFSET = 10.0f;
 
 World_Game1::World_Game1()
 {
@@ -29,6 +33,8 @@ World_Game1::World_Game1()
 void World_Game1::onInitialize()
 {
 	SCOPED_CPU_COUNTER(World_Game1_initialize);
+
+	getCamera().lookAt(CAMERA_POSITION, CAMERA_LOOK_AT, vector3(0.0f, 1.0f, 0.0f));
 
 	prepareAssets();
 	reloadScene();
@@ -66,7 +72,7 @@ void World_Game1::prepareAssets()
 	M_color->setConstantParameter("roughness", 0.2f);
 	M_color->setConstantParameter("emissive", vector3(0.0f));
 
-	GLuint landscapeAlbedo = pathos::createTextureFromBitmap(pathos::loadImage("resources/racing_game/landscape.jpg"), true, true);
+	GLuint landscapeAlbedo = pathos::createTextureFromBitmap(pathos::loadImage(LANDSCAPE_ALBEDO_MAP), true, true);
 	Material* M_landscape = pathos::createPBRMaterial(landscapeAlbedo);
 
 	auto G_sphere = new SphereGeometry(1.0f, 30);
@@ -111,6 +117,8 @@ void World_Game1::reloadScene()
 	// reloadScene() destroys all actors so respawn here :/
 	playerController = spawnActor<PlayerController>();
 	playerController->setPlayerPawn(sphere0);
+	playerController->cameraHeightOffset = PLAYERCAM_HEIGHT_OFFSET;
+	playerController->cameraForwardOffset = PLAYERCAM_FORWARD_OFFSET;
 
 	cloudscape = spawnActor<VolumetricCloudActor>();
 	cloudscape->setTextures(weatherTexture, cloudShapeNoise, cloudErosionNoise);

--- a/projects/Test_RacingGame/src/world_game1.h
+++ b/projects/Test_RacingGame/src/world_game1.h
@@ -4,9 +4,6 @@
 #include "pathos/scene/world.h"
 using namespace pathos;
 
-extern const vector3       CAMERA_POSITION;
-extern const vector3       CAMERA_LOOK_AT;
-
 namespace pathos {
 	class VolumetricCloudActor;
 	class SkyAtmosphereActor;

--- a/projects/Test_SkeletalAnimation/src/daeloader.h
+++ b/projects/Test_SkeletalAnimation/src/daeloader.h
@@ -23,7 +23,7 @@ namespace pathos {
 		DAELoader();
 		DAELoader(
 			const char* filename, const char* material_dir,
-			unsigned int flags = aiProcessPreset_TargetRealtime_MaxQuality,
+			unsigned int assimpFlags = aiProcessPreset_TargetRealtime_MaxQuality,
 			bool invertWinding = false);
 
 		virtual ~DAELoader();

--- a/projects/Test_SkeletalAnimation/src/main.cpp
+++ b/projects/Test_SkeletalAnimation/src/main.cpp
@@ -6,10 +6,6 @@ using namespace pathos;
 constexpr int32     WINDOW_WIDTH    = 1920;
 constexpr int32     WINDOW_HEIGHT   = 1080;
 constexpr char*     WINDOW_TITLE    = "Test: Skeletal Animation";
-constexpr float     FOVY            = 60.0f;
-const     vector3   CAMERA_POSITION = vector3(0.0f, 0.0f, 500.0f);
-constexpr float     CAMERA_Z_NEAR   = 1.0f;
-constexpr float     CAMERA_Z_FAR    = 10000.0f;
 
 int main(int argc, char** argv) {
 	EngineConfig conf;
@@ -18,11 +14,7 @@ int main(int argc, char** argv) {
 	conf.title        = WINDOW_TITLE;
 	Engine::init(argc, argv, conf);
 
-	const float ar = static_cast<float>(conf.windowWidth) / static_cast<float>(conf.windowHeight);
-
 	World* world2 = new World2;
-	world2->getCamera().lookAt(CAMERA_POSITION, CAMERA_POSITION + vector3(0.0f, 0.0f, -1.0f), vector3(0.0f, 1.0f, 0.0f));
-	world2->getCamera().changeLens(PerspectiveLens(FOVY, ar, CAMERA_Z_NEAR, CAMERA_Z_FAR));
 
 	gEngine->setWorld(world2);
 	gEngine->start();

--- a/projects/Test_SkeletalAnimation/src/player_controller.cpp
+++ b/projects/Test_SkeletalAnimation/src/player_controller.cpp
@@ -26,17 +26,17 @@ void PlayerController::onTick(float deltaSeconds)
 
 	// movement per seconds
 	const float moveMultiplier = badger::max(1.0f, input->getAxis("moveFast") * 10.0f);
-	const float speedRight = 200.0f * deltaSeconds * moveMultiplier;
-	const float speedForward = 200.0f * deltaSeconds * moveMultiplier;
-	const float speedUp = 200.0f * deltaSeconds * moveMultiplier;
-	const float rotateYaw = 120.0f * deltaSeconds;
-	const float rotatePitch = 120.0f * deltaSeconds;
+	const float speedRight   = 2.0f * deltaSeconds * moveMultiplier;
+	const float speedForward = 2.0f * deltaSeconds * moveMultiplier;
+	const float speedUp      = 2.0f * deltaSeconds * moveMultiplier;
+	const float rotateYaw    = 120.0f * deltaSeconds;
+	const float rotatePitch  = 120.0f * deltaSeconds;
 
-	float deltaRight = input->getAxis("moveRight") * speedRight;
+	float deltaRight   = input->getAxis("moveRight") * speedRight;
 	float deltaForward = input->getAxis("moveForward") * speedForward;
-	float deltaUp = input->getAxis("moveUp") * speedUp;
-	float rotY = 0.1f * (currMouseX - prevMouseX) * rotateYaw;
-	float rotX = 0.1f * (currMouseY - prevMouseY) * rotatePitch;
+	float deltaUp      = input->getAxis("moveUp") * speedUp;
+	float rotY         = 0.1f * (currMouseX - prevMouseX) * rotateYaw;
+	float rotX         = 0.1f * (currMouseY - prevMouseY) * rotatePitch;
 
 	camera.moveForward(deltaForward);
 	camera.moveRight(deltaRight);

--- a/projects/Test_SkeletalAnimation/src/skinned_mesh.cpp
+++ b/projects/Test_SkeletalAnimation/src/skinned_mesh.cpp
@@ -14,7 +14,7 @@ namespace pathos {
 		if (boneMapping.size() <= geomIndex) {
 			boneMapping.resize(geomIndex + 1);
 		}
-		boneMapping[geomIndex].push_back(std::move(bone));
+		boneMapping[geomIndex].push_back(bone);
 	}
 
 	void SkinnedMesh::addAnimation(SkeletalAnimation* animation) {
@@ -40,7 +40,7 @@ namespace pathos {
 		if (initialPositionsMapping.size() <= geomIndex) {
 			initialPositionsMapping.resize(geomIndex + 1);
 		}
-		initialPositionsMapping[geomIndex] = std::move(positions0);
+		initialPositionsMapping[geomIndex] = positions0;
 	}
 
 	void SkinnedMesh::updateSoftwareSkinning() {
@@ -68,10 +68,9 @@ namespace pathos {
 			++geomIndex;
 		}
 	}
-	void SkinnedMesh::updateAnimation(int index, double progress) {
+	void SkinnedMesh::updateAnimation(int index, double time) {
 		aiAnimation* anim = animations[index]->anim;
-		progress = std::min(1.0, std::max(0.0, progress));
-		double time = anim->mDuration * progress;
+		time = std::max(0.0, std::min(time, anim->mDuration));
 
 		for (auto i = 0u; i < anim->mNumChannels; ++i) {
 			aiNodeAnim* chan = anim->mChannels[i];
@@ -92,11 +91,11 @@ namespace pathos {
 			node->localTransform = T * R * S;
 		}
 	}
-	void SkinnedMesh::updateAnimation(std::string name, double progress) {
+	void SkinnedMesh::updateAnimation(const std::string& name, double time) {
 		// TODO: encalsulate aiAnimation
 		for (auto i = 0u; i < animations.size(); ++i) {
 			if (std::string(animations[i]->getName()) == name) {
-				updateAnimation(i, progress);
+				updateAnimation(i, time);
 				break;
 			}
 		}

--- a/projects/Test_SkeletalAnimation/src/skinned_mesh.h
+++ b/projects/Test_SkeletalAnimation/src/skinned_mesh.h
@@ -34,14 +34,16 @@ namespace pathos {
 			nodeTransformMapping[name] = transform;
 		}
 
-		// TODO: switch to hardware skinning
+		// #todo-skinning: switch to hardware skinning
 		void setInitialPositions(uint32_t geomIndex, const std::vector<float>& positions0);
 		void updateSoftwareSkinning();
-		void updateAnimation(std::string name, double progress);
+		void updateAnimation(const std::string& name, double progress);
 		void updateAnimation(int index, double progress);
 		void updateGlobalTransform();
 
 		inline ModelTransform& getTransform() { return transform; }
+		inline SkeletalAnimation* getAnimationInfo(size_t ix) const { return animations[ix]; }
+		inline size_t numAnimations() const { return animations.size(); }
 
 	protected:
 		ModelTransform transform;
@@ -52,9 +54,9 @@ namespace pathos {
 		std::vector<SkeletalAnimation*> animations;
 		std::map<std::string, Node*> nodeMapping;
 		std::map<std::string, glm::mat4> nodeTransformMapping;
-		Node* root;
+		Node* root = nullptr;
 
-		// TODO: switch to hardware skinning
+		// #todo-skinning: switch to hardware skinning
 		void updateBoneTransform();
 
 		int translation_lower_bound(aiNodeAnim* channel, double time);

--- a/projects/Test_SkeletalAnimation/src/world2.cpp
+++ b/projects/Test_SkeletalAnimation/src/world2.cpp
@@ -20,8 +20,8 @@
 
 #define DIR_MY_ANIMTEST           "resources/models/animtest/"
 #define FILE_MY_ANIMTEST          "resources/models/animtest/animtest.dae"
-#define DIR_RIGGED_FIGURE         "resources_external/"
-#define FILE_RIGGED_FIGURE        "resources_external/RiggedFigure.dae"
+#define DIR_RIGGED_FIGURE         "resources_external/KhronosGroup/RiggedFigure/"
+#define FILE_RIGGED_FIGURE        "resources_external/KhronosGroup/RiggedFigure/RiggedFigure.dae"
 #define DOWNLOAD_ALERT_MSG1       L"If you can't see 2 animated models, run Setup.ps1"
 #define DOWNLOAD_ALERT_MSG2       L"움직이는 모델 2개가 표시되지 않으면 Setup.ps1을 실행해주세요"
 

--- a/projects/Test_SkeletalAnimation/src/world2.cpp
+++ b/projects/Test_SkeletalAnimation/src/world2.cpp
@@ -1,4 +1,4 @@
-#include "world2.h"
+﻿#include "world2.h"
 #include "daeloader.h"
 #include "skinned_mesh.h"
 #include "player_controller.h"
@@ -8,18 +8,28 @@
 #include "pathos/gui/gui_window.h"
 #include "pathos/scene/static_mesh_actor.h"
 #include "pathos/scene/skybox_actor.h"
+#include "pathos/text/text_actor.h"
 
 #include <time.h>
 
-#define DAE_MODEL_ID              2
-#define LOAD_SECOND_DAE_MODEL     0
+#define FOV_Y                     60.0f
+#define SUN_DIRECTION             glm::normalize(vector3(0.0f, -1.0f, 1.0f))
+#define SUN_ILLUMINANCE           vector3(2.0f)
+#define CAMERA_POSITION           vector3(0.0f, 2.0f, 6.0f)
+#define CAMERA_LOOK_AT            vector3(0.0f, 2.0f, 4.0f)
 
-#define DEBUG_TEXT_ACTOR          1
-#include "pathos/text/text_actor.h"
+#define DIR_MY_ANIMTEST           "resources/models/animtest/"
+#define FILE_MY_ANIMTEST          "resources/models/animtest/animtest.dae"
+#define DIR_RIGGED_FIGURE         "resources_external/"
+#define FILE_RIGGED_FIGURE        "resources_external/RiggedFigure.dae"
+#define DOWNLOAD_ALERT_MSG1       L"If you can't see 2 animated models, run Setup.ps1"
+#define DOWNLOAD_ALERT_MSG2       L"움직이는 모델 2개가 표시되지 않으면 Setup.ps1을 실행해주세요"
 
 
 void World2::onInitialize()
 {
+	getCamera().lookAt(CAMERA_POSITION, CAMERA_LOOK_AT, vector3(0.0f, 1.0f, 0.0f));
+
 	playerController = spawnActor<PlayerController>();
 
 	setupScene();
@@ -28,37 +38,23 @@ void World2::onInitialize()
 
 void World2::onTick(float deltaSeconds)
 {
-	static float modelYaw = 0.0f;
-	model->setActorRotation(Rotator(modelYaw += 30.0f * deltaSeconds, 0.0f, 0.0f));
-	model->setActorLocation(vector3(0, -200, 0));
+	static double animTime = 0.0;
+	animTime += deltaSeconds;
 
-	// Dummy boxes
-	for (uint32 i = 0; i < (uint32)boxes.size(); ++i)
-	{
-		Rotator rotator = boxes[i]->getActorRotation();
-		rotator.yaw += 30.0f * deltaSeconds;
-		boxes[i]->setActorRotation(rotator);
+	if (daeModel_my != nullptr) {
+		double duration = daeModel_my->getAnimationInfo(0)->getLength();
+		double time = ::fmod(animTime, duration * 2);
+		if (time > duration) time = duration * 2 - time;
+		daeModel_my->updateAnimation(0, time);
+		daeModel_my->updateSoftwareSkinning();
 	}
-
-#if DAE_MODEL_ID == 2
-	if (daeModel != nullptr) {
-		static double time = 0.0;
-		time += deltaSeconds;
-		if (time > 1.0) time = 0.0;
-		daeModel->updateAnimation(0, time);
-		daeModel->updateSoftwareSkinning();
-	}
-#endif
-
-	// Update window title
+	if (daeModel_riggedFigure != nullptr)
 	{
-		char title[256];
-		sprintf_s(title, "%s (GameThread: %.2f ms, RenderThread: %.2f ms, GPU: %.2f ms)",
-			gEngine->getConfig().title,
-			gEngine->getGameThreadCPUTime(),
-			gEngine->getRenderThreadCPUTime(),
-			gEngine->getGPUTime());
-		gEngine->getMainWindow()->setTitle(title);
+		double duration = daeModel_riggedFigure->getAnimationInfo(0)->getLength();
+		double time = ::fmod(animTime, duration * 2);
+		if (time > duration) time = duration * 2 - time;
+		daeModel_riggedFigure->updateAnimation(0, time);
+		daeModel_riggedFigure->updateSoftwareSkinning();
 	}
 }
 
@@ -66,16 +62,19 @@ void World2::setupScene()
 {
 	srand(static_cast<unsigned int>(time(NULL)));
 
-	dirLight = spawnActor<DirectionalLightActor>();
-	dirLight->setLightParameters(vector3(0.0f, 0.0f, -1.0f), vector3(1.0f));
+	sunLight = spawnActor<DirectionalLightActor>();
+	sunLight->setDirection(SUN_DIRECTION);
+	sunLight->setIlluminance(SUN_ILLUMINANCE);
 
 	pointLight0 = spawnActor<PointLightActor>();
-	pointLight0->setActorLocation(vector3(0.0f, 0.0f, 0.0f));
-	pointLight0->setLightParameters(vector3(1.0f));
+	pointLight0->setActorLocation(vector3(0.0f, 2.0f, 2.0f));
+	pointLight0->setIntensity(100.0f * vector3(1.0f, 5.0f, 1.0f));
+	pointLight0->setAttenuationRadius(10.0f);
+	pointLight0->setSourceRadius(0.2f);
 
 	//---------------------------------------------------------------------------------------
-	// create materials
-	//---------------------------------------------------------------------------------------
+	// Materials
+
 	std::array<const char*, 6> cubeImageNames = {
 		"skybox/cubemap1/pos_x.jpg", "skybox/cubemap1/neg_x.jpg",
 		"skybox/cubemap1/pos_y.jpg", "skybox/cubemap1/neg_y.jpg",
@@ -85,116 +84,96 @@ void World2::setupScene()
 	pathos::loadCubemapImages(cubeImageNames, ECubemapImagePreference::HLSL, cubeImageBlobs);
 	GLuint cubeTexture = pathos::createCubemapTextureFromBitmap(cubeImageBlobs.data());
 
-	GLuint tex = pathos::createTextureFromBitmap(loadImage("textures/154.jpg"), true, true);
-	GLuint tex_norm = pathos::createTextureFromBitmap(loadImage("textures/154_norm.jpg"), true, false);
-
-	//auto material_texture = PBRTextureMaterial::createWithFallback(tex);
-	Material* material_texture = pathos::createPBRMaterial(tex);
-	
 	Material* material_color = Material::createMaterialInstance("solid_color");
 	material_color->setConstantParameter("albedo", vector3(0.9f, 0.9f, 0.9f));
 	material_color->setConstantParameter("metallic", 0.0f);
 	material_color->setConstantParameter("roughness", 0.5f);
 	material_color->setConstantParameter("emissive", vector3(0.0f));
 
-	//---------------------------------------------------------------------------------------
-	// create geometries
-	//---------------------------------------------------------------------------------------
+	Material* material_ground = Material::createMaterialInstance("solid_color");
+	material_ground->setConstantParameter("albedo", vector3(0.5f, 0.5f, 0.5f));
+	material_ground->setConstantParameter("metallic", 0.0f);
+	material_ground->setConstantParameter("roughness", 1.0f);
+	material_ground->setConstantParameter("emissive", vector3(0.0f));
 
-	auto geom_sphere_big = new SphereGeometry(15.0f, 30);
+	//---------------------------------------------------------------------------------------
+	// Geometries
+
 	auto geom_sphere = new SphereGeometry(5.0f, 30);
-	auto geom_plane = new PlaneGeometry(10.f, 10.f);
-	auto geom_cube = new CubeGeometry(vector3(5.0f));
+	auto geom_plane = new PlaneGeometry(100.0f, 100.0f);
 
 	//---------------------------------------------------------------------------------------
-	// create meshes
-	//---------------------------------------------------------------------------------------
+	// Actors
 
-#if !DEBUG_TEXT_ACTOR
-	for (int32_t i = 0; i < 8; ++i) {
-		for (int32_t j = 0; j < 4; ++j) {
-			StaticMeshActor* cube = spawnActor<StaticMeshActor>();
-			cube->setStaticMesh(new Mesh(geom_cube, material_color));
+	ground = spawnActor<StaticMeshActor>();
+	ground->setStaticMesh(new Mesh(geom_plane, material_ground));
+	ground->setActorLocation(0.0f, 0.0f, 0.0f);
+	ground->setActorRotation(Rotator(0.0f, -90.0f, 0.0f));
+	ground->getStaticMesh()->doubleSided = true;
 
-			vector3 p0(-150.0f, 150.0f, -50.0f);
-			float yaw = (float)(rand() % 180);
-			float pitch = (float)(rand() % 90);
-			float roll = (float)(rand() % 180);
-			cube->setActorRotation(Rotator(yaw, pitch, roll));
-			cube->setActorLocation(p0 + vector3(i * 45.0f, -j * 45.0f, 0.0f));
-			cube->setActorScale(3.0f);
+	godRaySourceMesh = spawnActor<StaticMeshActor>();
+	godRaySourceMesh->setStaticMesh(new Mesh(geom_sphere, material_color));
+	godRaySourceMesh->setActorLocation(vector3(0.0f, 100.0f, -500.0f));
 
-			boxes.push_back(cube);
-		}
-	}
-#endif
+	alertText1 = spawnActor<TextMeshActor>();
+	alertText1->setFont("hangul");
+	alertText1->setText(DOWNLOAD_ALERT_MSG1);
+	alertText1->setActorLocation(-5.0f, 4.0f, 0.0f);
+	alertText1->setColor(0.3f, 0.9f, 0.3f);
+	alertText1->setActorScale(8.0f);
 
-	model = spawnActor<StaticMeshActor>();
-	model->setStaticMesh(new Mesh(geom_sphere_big, material_texture));
-	model->setActorLocation(vector3(-40.0f, 0.0f, 0.0f));
-	model->setActorScale(10.0f);
-
-	model2 = spawnActor<StaticMeshActor>();
-	model2->setStaticMesh(new Mesh(geom_sphere, material_color));
-	model2->setActorScale(30.0f);
-	model2->setActorLocation(vector3(0.0f, 50.0f, -400.0f));
-
-#if DEBUG_TEXT_ACTOR
-	text1 = spawnActor<TextMeshActor>();
-	text1->setFont("hangul");
-	text1->setText(L"ABCDEFG TextTest �ѱ�");
-	text1->setActorLocation(100.0f, 50.0f, 0.0f);
-	text1->setColor(0.1f, 0.9f, 0.1f);
-	text1->setActorScale(1000.0f);
-#endif
+	alertText2 = spawnActor<TextMeshActor>();
+	alertText2->setFont("hangul");
+	alertText2->setText(DOWNLOAD_ALERT_MSG2);
+	alertText2->setActorLocation(-5.0f, 3.0f, 0.0f);
+	alertText2->setColor(0.9f, 0.1f, 0.9f);
+	alertText2->setActorScale(8.0f);
 
 	SkyboxActor* sky = spawnActor<SkyboxActor>();
 	sky->initialize(cubeTexture);
 
 	scene.sky = sky;
-	scene.godRaySource = model2->getStaticMeshComponent();
+	scene.godRaySource = godRaySourceMesh->getStaticMeshComponent();
 }
 
 void World2::loadDAE()
 {
-	bool invertWinding = false;
-#if DAE_MODEL_ID == 0
-	const std::string dir = "models/LOL_ashe/";
-	const std::string model = dir + "Ashe.dae";
-#elif DAE_MODEL_ID == 1
-	const std::string dir = "models/LOL_project_ashe/";
-	const std::string model = dir + "Project_Ashe.dae";
-	invertWinding = true;
-#else
-	const std::string dir = "models/animtest/";
-	const std::string model = dir + "animtest.dae";
-#endif
+	auto debugPrintDAE = [](SkinnedMesh* skinnedMesh) {
+		LOG(LogInfo, "Num animations: %u", skinnedMesh->numAnimations());
+		for (size_t i = 0; i < skinnedMesh->numAnimations(); ++i)
+		{
+			SkeletalAnimation* anim = skinnedMesh->getAnimationInfo(i);
+			LOG(LogInfo, "    length=%lf", anim->getLength());
+			LOG(LogInfo, "    name=%s", anim->getName().c_str());
+		}
+	};
 
-	DAELoader loader(model.c_str(), dir.c_str(), aiProcessPreset_TargetRealtime_MaxQuality, invertWinding);
-	if (loader.getMesh()) {
-		daeModel = dynamic_cast<SkinnedMesh*>(loader.getMesh());
+	DAELoader loader1(FILE_MY_ANIMTEST, DIR_MY_ANIMTEST);
+	if (loader1.getMesh()) {
+		daeModel_my = dynamic_cast<SkinnedMesh*>(loader1.getMesh());
+		debugPrintDAE(daeModel_my);
 
 		StaticMeshActor* daeActor = spawnActor<StaticMeshActor>();
-		daeActor->setStaticMesh(daeModel);
+		daeActor->setStaticMesh(daeModel_my);
 
-		daeActor->setActorScale(10.0f);
-#if DAE_MODEL_ID == 2
-		daeActor->setActorScale(20.0f);
-		daeActor->setActorRotation(Rotator(90.0f, 0.0f, 0.0f));
-#endif
 		daeActor->setActorLocation(vector3(0.0f, 0.0f, 0.0f));
+		daeActor->setActorRotation(Rotator(90.0f, 0.0f, 0.0f));
+		daeActor->setActorScale(0.2f);
 	} else {
-		LOG(LogError, "Failed to load model: %s", model.c_str());
+		LOG(LogError, "Failed to load model: %s", FILE_MY_ANIMTEST);
 	}
 
-#if LOAD_SECOND_DAE_MODEL
-	const std::string dir2 = "models/Sonic/";
-	const std::string model2 = dir2 + "Sonic.dae";
-	DAELoader loader2(model2.c_str(), dir2.c_str(), aiProcessPreset_TargetRealtime_MaxQuality);
-	daeModel2 = dynamic_cast<SkinnedMesh*>(loader2.getMesh());
-	daeModel2->getTransform().appendScale(10.0f);
-	daeModel2->getTransform().appendMove(20.0f, 0.0f, 50.0f);
-	scene.add(daeModel2);
-#endif
-}
+	DAELoader loader2(FILE_RIGGED_FIGURE, DIR_RIGGED_FIGURE);
+	if (loader2.getMesh()) {
+		daeModel_riggedFigure = dynamic_cast<SkinnedMesh*>(loader2.getMesh());
+		debugPrintDAE(daeModel_riggedFigure);
 
+		StaticMeshActor* daeActor = spawnActor<StaticMeshActor>();
+		daeActor->setStaticMesh(daeModel_riggedFigure);
+
+		daeActor->setActorLocation(vector3(1.5f, 0.0f, 0.0f));
+		daeActor->setActorRotation(Rotator(0.0f, 0.0f, 0.0f));
+	} else {
+		LOG(LogError, "Failed to load model: %s", FILE_RIGGED_FIGURE);
+	}
+}

--- a/projects/Test_SkeletalAnimation/src/world2.h
+++ b/projects/Test_SkeletalAnimation/src/world2.h
@@ -27,15 +27,16 @@ public:
 private:
 	PlayerController* playerController = nullptr;
 
-	DirectionalLightActor* dirLight = nullptr;
+	DirectionalLightActor* sunLight = nullptr;
 	PointLightActor* pointLight0 = nullptr;
 
-	StaticMeshActor* model = nullptr;
-	StaticMeshActor* model2 = nullptr;
-	SkinnedMesh* daeModel = nullptr;
-	SkinnedMesh* daeModel2 = nullptr;
-	std::vector<StaticMeshActor*> boxes;
+	StaticMeshActor* ground = nullptr;
+	StaticMeshActor* godRaySourceMesh = nullptr;
 
-	TextMeshActor* text1 = nullptr;
+	SkinnedMesh* daeModel_my = nullptr;
+	SkinnedMesh* daeModel_riggedFigure = nullptr;
+
+	TextMeshActor* alertText1 = nullptr;
+	TextMeshActor* alertText2 = nullptr;
 
 };

--- a/resources/racing_game/test_scene.json
+++ b/resources/racing_game/test_scene.json
@@ -22,14 +22,14 @@
 		{
 			"name": "Sun",
 			"direction": [0, -0.4, -1],
-			"radiance": [1.2, 1.2, 1.2]
+			"illuminance": [1.2, 1.2, 1.2]
 		}
 	],
 	"pointLight": [
 		{
 			"name": "PointLight0",
 			"location": [0.0, 0.5, 4.0],
-			"radiance": [10, 100, 10],
+			"intensity": [10, 100, 10],
 			"attenuationRadius": 50,
 			"falloffExponent": 0.001,
 			"castsShadow": true

--- a/resources/racing_game/test_scene.json
+++ b/resources/racing_game/test_scene.json
@@ -28,9 +28,9 @@
 	"pointLight": [
 		{
 			"name": "PointLight0",
-			"location": [-20, 5, 20],
-			"radiance": [0, 10, 0],
-			"attenuationRadius": 1000,
+			"location": [0.0, 0.5, 4.0],
+			"radiance": [10, 100, 10],
+			"attenuationRadius": 50,
 			"falloffExponent": 0.001,
 			"castsShadow": true
 		}
@@ -40,13 +40,13 @@
 			"name": "Sphere0",
 			"location": [0, 0, 0],
 			"rotation": [0, 0, 0],
-			"scale": [15, 15, 15]
+			"scale": [1, 1, 1]
 		},
 		{
 			"name": "Landscape",
-			"location": [0, -20, 0],
+			"location": [0, -1.0, 0],
 			"rotation": [0, -90, 0],
-			"scale": [100, 100, 1]
+			"scale": [100, 100, 100]
 		}
 	]
 }

--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -1,5 +1,7 @@
 //? #version 460 core
 
+// #todo: If you see a term 'radiance' in shaders, probably it means 'luminance'.
+
 // #todo: Remove common defines in separate .glsl files and use common.glsl
 #define PI         3.14159265359
 #define TWO_PI     6.28318530718

--- a/shaders/shadow_mapping.glsl
+++ b/shaders/shadow_mapping.glsl
@@ -43,7 +43,7 @@ float getShadowingFactor(sampler2DArrayShadow csm, ShadowQuery query) {
 #endif
 
 	const float SLOPE_BIAS = 0.005;
-	const float NORMAL_OFFSET = 10.0; // #todo-glsl: Magic value for world_rc1, but too big for world1.
+	const float NORMAL_OFFSET = 0.01; // #todo-glsl: Magic value for world_rc1, but too big for world1.
 
 	// Convert world query position to the shadow texture coordinate
 	vec4 ls_coords = uboPerFrame.sunViewProjection[csmLayer] * vec4(query.wPos + NORMAL_OFFSET * query.wNormal, 1.0);


### PR DESCRIPTION
World distance measurement didn't have any physical meaning. Now everything is expressed in meters.

Once considered using *centimeter* as unit distance, but external 3D models normally assumes meter and standard photometric light units also involve meter, not centimeter.

Misc

* Download RiggedFigure and DamagedHelmet assets from KhronosGroup's glTF repo, via Setup.ps1.
* Add RiggedFigure model to Test_SkeletalAnimation project.
* Add world_sponza to world rotation list of Test_DeferredRenderer project. (though it actually renders DamagedHelmet, not Sponza scene. Intel Sponza is way too big to include in download list)
* Limit max FPS to 1000 by default to prevent deltaSeconds from being zero.
* Fix default normalmap for pbr_texture material.