### PR TITLE
Feature/62 sky progressive update

### DIFF
--- a/projects/PathosEngine/PathosEngine.vcxproj
+++ b/projects/PathosEngine/PathosEngine.vcxproj
@@ -101,6 +101,7 @@
     <ClCompile Include="src\pathos\scene\landscape_actor.cpp" />
     <ClCompile Include="src\pathos\scene\landscape_component.cpp" />
     <ClCompile Include="src\pathos\scene\physics_component.cpp" />
+    <ClCompile Include="src\pathos\scene\sky_common.cpp" />
     <ClCompile Include="src\thirdparty\gl3w.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
@@ -276,6 +277,7 @@
     <ClInclude Include="src\pathos\scene\reflection_probe_actor.h" />
     <ClInclude Include="src\pathos\scene\reflection_probe_component.h" />
     <ClInclude Include="src\pathos\scene\scene_component.h" />
+    <ClInclude Include="src\pathos\scene\sky_common.h" />
     <ClInclude Include="src\pathos\scene\world.h" />
     <ClInclude Include="src\pathos\scene\camera.h" />
     <ClInclude Include="src\pathos\console.h" />

--- a/projects/PathosEngine/PathosEngine.vcxproj.filters
+++ b/projects/PathosEngine/PathosEngine.vcxproj.filters
@@ -404,6 +404,9 @@
     <ClCompile Include="src\pathos\rhi\sampler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\pathos\scene\sky_common.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\pathos\text\text_geometry.h">
@@ -935,6 +938,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\badger\math\bits.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\pathos\scene\sky_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/projects/PathosEngine/src/pathos/render/indirect_lighting.cpp
+++ b/projects/PathosEngine/src/pathos/render/indirect_lighting.cpp
@@ -31,6 +31,7 @@ namespace pathos {
 
 	static constexpr uint32 SSBO_IrradianceVolume_BINDING_SLOT = 2; // Irradiance volumes
 	static constexpr uint32 SSBO_ReflectionProbe_BINDING_SLOT = 3; // Reflection probes
+	static constexpr uint32 SSBO_SkyDiffuseSH_BINDING_SLOT = 4;
 
 	struct UBO_IndirectLighting {
 		static const uint32 BINDING_SLOT = 1;
@@ -161,7 +162,7 @@ namespace pathos {
 		ubo.update(cmdList, UBO_IndirectLighting::BINDING_SLOT, &uboData);
 		cmdList.bindBufferBase(GL_SHADER_STORAGE_BUFFER, SSBO_IrradianceVolume_BINDING_SLOT, irradianceVolumeBuffer);
 		cmdList.bindBufferBase(GL_SHADER_STORAGE_BUFFER, SSBO_ReflectionProbe_BINDING_SLOT, reflectionProbeBuffer);
-		sceneContext.skyDiffuseSH->bindAsSSBO(cmdList, 4);
+		sceneContext.skyDiffuseSH->bindAsSSBO(cmdList, SSBO_SkyDiffuseSH_BINDING_SLOT);
 
 		GLuint* gbuffer_textures = (GLuint*)cmdList.allocateSingleFrameMemory(3 * sizeof(GLuint));
 		gbuffer_textures[0] = sceneContext.gbufferA;
@@ -185,6 +186,7 @@ namespace pathos {
 		fullscreenQuad->drawPrimitive(cmdList);
 
 		// Fix a strange bug that IBL maps are randomly persistent across worlds.
+		cmdList.bindBuffersBase(GL_SHADER_STORAGE_BUFFER, SSBO_IrradianceVolume_BINDING_SLOT, 3, nullptr);
 		cmdList.bindTextures(0, 10, nullptr);
 
 		// Restore render states

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
@@ -465,7 +465,7 @@ namespace pathos {
 		cmdList.memoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 	}
 
-	void LightProbeBaker::blitCubemap_renderThread(RenderCommandList& cmdList, Texture* input, Texture* output, uint32 inputMip, uint32 outputMip) {
+	void LightProbeBaker::blitCubemap_renderThread(RenderCommandList& cmdList, Texture* input, Texture* output, uint32 inputMip, uint32 outputMip, int32 faceBegin, int32 faceEnd) {
 		SCOPED_DRAW_EVENT(BlitCubemap);
 
 		const GLuint outputSize = output->getCreateParams().width >> outputMip;
@@ -484,7 +484,7 @@ namespace pathos {
 
 		dummyCube->bindPositionOnlyVAO(cmdList);
 
-		for (int32 i = 0; i < 6; ++i) {
+		for (int32 i = faceBegin; i <= faceEnd; ++i) {
 			const matrix4& viewproj = cubeTransforms[i];
 
 			cmdList.namedFramebufferTextureLayer(dummyFBO, GL_COLOR_ATTACHMENT0, output->internal_getGLName(), outputMip, i);

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
@@ -210,7 +210,6 @@ namespace pathos {
 
 		cmdList.memoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT);
 
-		// #wip: Sky lighting flickers due to diffuse SH shader (world_rc1), maybe barrier bug
 		uint32 groupSize = (cubemapSize + 7) / 8;
 		cmdList.dispatchCompute(groupSize, groupSize, 1);
 

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
@@ -208,6 +208,9 @@ namespace pathos {
 		cmdList.bindTextureUnit(0, inCubemap->internal_getGLName());
 		outSH->bindAsSSBO(cmdList, 2);
 
+		cmdList.memoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT);
+
+		// #wip: Sky lighting flickers due to diffuse SH shader (world_rc1), maybe barrier bug
 		uint32 groupSize = (cubemapSize + 7) / 8;
 		cmdList.dispatchCompute(groupSize, groupSize, 1);
 
@@ -458,6 +461,8 @@ namespace pathos {
 		const GLint layer = 0; // Don't care if layere = GL_TRUE
 		cmdList.bindImageTexture(0, input->internal_getGLName(), inputMip, GL_TRUE, layer, GL_READ_ONLY, inputDesc.glStorageFormat);
 		cmdList.bindImageTexture(1, output->internal_getGLName(), outputMip, GL_TRUE, layer, GL_WRITE_ONLY, inputDesc.glStorageFormat);
+
+		cmdList.memoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 
 		const uint32 groupSize = (mipSize + 7) / 8;
 		cmdList.dispatchCompute(groupSize, groupSize, 1);

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
@@ -210,6 +210,7 @@ namespace pathos {
 
 		cmdList.memoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT);
 
+		// #wip: Still have barrier bug? :/
 		uint32 groupSize = (cubemapSize + 7) / 8;
 		cmdList.dispatchCompute(groupSize, groupSize, 1);
 

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.cpp
@@ -431,6 +431,7 @@ namespace pathos {
 		cmdList.cullFace(GL_BACK);
 	}
 
+	// #todo-rhi: Too slow? 0.3 ms for 128x128 cubemaps?
 	void LightProbeBaker::copyCubemap_renderThread(RenderCommandList& cmdList, Texture* input, Texture* output, uint32 inputMip /*= 0*/, uint32 outputMip /*= 0*/) {
 		SCOPED_DRAW_EVENT(CopyCubemap);
 

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.h
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.h
@@ -42,6 +42,7 @@ namespace pathos {
 
 		/// <summary>
 		/// Generate irradiance cubemap from radiance capture cubemap.
+		/// NOTE: This is very expensive. Use bakeDiffuseSH_renderThread() if possible.
 		/// </summary>
 		/// <param name="cmdList">Render command list</param>
 		/// <param name="inputRadianceCubemap">Input radiance cubemap</param>
@@ -55,6 +56,7 @@ namespace pathos {
 
 		/// <summary>
 		/// Render specular IBL cubemap from radiance capture cubemap.
+		/// NOTE: This is very expensive. Use bakeReflectionProbe_renderThread() if possible.
 		/// </summary>
 		/// <param name="cmdList">Render command list</param>
 		/// <param name="inputTexture">Input radiance cubemap</param>

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.h
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.h
@@ -95,11 +95,15 @@ namespace pathos {
 		/// <param name="inputTexture">Input panorama texture2D</param>
 		/// <param name="outputTexture">Output textureCube</param>
 		/// <param name="outputTextureSize">Output texture size</param>
+		/// <param name="faceBegin">First face of output texture to project. Inclusive.</param>
+		/// <param name="faceEnd">Last face of output texture to project. Inclusive.</param>
 		void projectPanoramaToCubemap_renderThread(
 			RenderCommandList& cmdList,
 			GLuint inputTexture,
 			GLuint outputTexture,
-			uint32 outputTextureSize);
+			uint32 outputTextureSize,
+			int32 faceBegin,
+			int32 faceEnd);
 
 		/// <summary>
 		/// New implementation for reflection probe filtering, but only support 128-sized cubemaps.

--- a/projects/PathosEngine/src/pathos/render/light_probe_baker.h
+++ b/projects/PathosEngine/src/pathos/render/light_probe_baker.h
@@ -86,7 +86,9 @@ namespace pathos {
 		/// <param name="output"></param>
 		/// <param name="inputMip"></param>
 		/// <param name="outputMip"></param>
-		void blitCubemap_renderThread(RenderCommandList& cmdList, Texture* input, Texture* output, uint32 inputMip, uint32 outputMip);
+		/// <param name="faceBegin"></param>
+		/// <param name="faceEnd"></param>
+		void blitCubemap_renderThread(RenderCommandList& cmdList, Texture* input, Texture* output, uint32 inputMip, uint32 outputMip, int32 faceBegin = 0, int32 faceEnd = 5);
 
 		/// <summary>
 		/// Render the given equirectangular (panorama) texture to the cubemap texture.

--- a/projects/PathosEngine/src/pathos/render/scene_render_targets.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_render_targets.cpp
@@ -451,8 +451,8 @@ namespace pathos {
 			skyPrefilteredMap = 0;
 		}
 
-		skyPrefilterMapMipCount = calcCubemapNumMips(cubemapSize, SKY_PREFILTER_MAP_MIN_SIZE);
-		skyPrefilterMapMipCount = std::min(skyPrefilterMapMipCount, SKY_PREFILTER_MAP_MAX_NUM_MIPS);
+		skyPrefilterMapMipCount = calcCubemapNumMips(cubemapSize, SKY_PREFILTER_MAP_SIZE);
+		skyPrefilterMapMipCount = std::min(skyPrefilterMapMipCount, SKY_PREFILTER_MAP_MIP_COUNT);
 		skyPrefilterMapSize = cubemapSize;
 		if (skyPrefilteredMap == 0) {
 			gRenderDevice->createTextures(GL_TEXTURE_CUBE_MAP, 1, &skyPrefilteredMap);

--- a/projects/PathosEngine/src/pathos/render/scene_render_targets.h
+++ b/projects/PathosEngine/src/pathos/render/scene_render_targets.h
@@ -9,12 +9,9 @@ namespace pathos {
 	class Texture;
 	struct DirectionalLightProxy;
 
-	constexpr uint32 SKY_AMBIENT_CUBEMAP_SIZE = 128; // Size of source cubemap of sky diffuse SH.
-
-	// For sky atmosphere and panorama sky. Skybox will use the size of its source cubemap.
-	constexpr uint32 SKY_PREFILTER_MAP_DEFAULT_SIZE = 512;
-	constexpr uint32 SKY_PREFILTER_MAP_MIN_SIZE = 128;
-	constexpr uint32 SKY_PREFILTER_MAP_MAX_NUM_MIPS = 5;
+	constexpr uint32 SKY_AMBIENT_CUBEMAP_SIZE    = 64;  // Size of source cubemap of sky diffuse SH.
+	constexpr uint32 SKY_PREFILTER_MAP_SIZE      = 128; // #note: Do not change this. LightProbeBaker::bakeReflectionProbe_renderThread() requires this specific value.
+	constexpr uint32 SKY_PREFILTER_MAP_MIP_COUNT = 7;   // #note: Do not change this. LightProbeBaker::bakeReflectionProbe_renderThread() requires this specific value.
 	
 	// Textures for scene rendering
 	// #todo-renderer: render target pool for temporary textures

--- a/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
+++ b/projects/PathosEngine/src/pathos/render/scene_renderer.cpp
@@ -310,7 +310,7 @@ namespace pathos {
 						sceneRenderTargets->skyPrefilteredMap,
 						sceneRenderTargets->skyPrefilterMapSize,
 						0, // start mip level
-						pathos::SKY_PREFILTER_MAP_MAX_NUM_MIPS, // mip count to clear
+						pathos::SKY_PREFILTER_MAP_MIP_COUNT, // mip count to clear
 						EClearTextureFormat::RGBA16f,
 						clearValues);
 				}

--- a/projects/PathosEngine/src/pathos/render/sky_atmosphere.cpp
+++ b/projects/PathosEngine/src/pathos/render/sky_atmosphere.cpp
@@ -228,8 +228,9 @@ namespace pathos {
 	void SkyAtmospherePass::generateCubemapMips(RenderCommandList& cmdList) {
 		SCOPED_DRAW_EVENT(SkyAtmosphereMips);
 
-		// Copy specular cubemap to ambient cubemap for diffuse SH.
 		cmdList.generateTextureMipmap(reflectionCubemap->internal_getGLName());
+
+		// Copy specular cubemap to ambient cubemap for diffuse SH.
 		int32 copyMip = badger::ctz(pathos::SKY_PREFILTER_MAP_SIZE) - badger::ctz(pathos::SKY_AMBIENT_CUBEMAP_SIZE);
 		LightProbeBaker::get().copyCubemap_renderThread(cmdList, reflectionCubemap, ambientCubemap, copyMip, 0);
 	}

--- a/projects/PathosEngine/src/pathos/render/sky_atmosphere.h
+++ b/projects/PathosEngine/src/pathos/render/sky_atmosphere.h
@@ -24,9 +24,10 @@ namespace pathos {
 
 	private:
 		void renderToScreen(RenderCommandList& cmdList, SceneProxy* scene, Camera* camera);
-		void renderToCubemap(RenderCommandList& cmdList, SceneProxy* scene);
-		void renderSkyDiffuseSH(RenderCommandList& cmdList);
-		void renderSkyPrefilterMap(RenderCommandList& cmdList, SceneProxy* scene);
+		void renderToCubemap(RenderCommandList& cmdList, SceneProxy* scene, int32 faceBegin, int32 faceEnd); // faceBegin/End are inclusive
+		void generateCubemapMips(RenderCommandList& cmdList);
+		void computeDiffuseSH(RenderCommandList& cmdList);
+		void filterSpecular(RenderCommandList& cmdList);
 		void renderTransmittanceLUT(RenderCommandList& cmdList, MeshGeometry* fullscreenQuad); // Called only once
 
 		GLuint fbo = 0xffffffff;

--- a/projects/PathosEngine/src/pathos/render/sky_panorama.cpp
+++ b/projects/PathosEngine/src/pathos/render/sky_panorama.cpp
@@ -151,8 +151,9 @@ namespace pathos {
 	void PanoramaSkyPass::generateCubemapMips(RenderCommandList& cmdList) {
 		SCOPED_DRAW_EVENT(SkyboxMips);
 
-		// Copy specular cubemap to ambient cubemap for diffuse SH.
 		cmdList.generateTextureMipmap(reflectionCubemap->internal_getGLName());
+
+		// Copy specular cubemap to ambient cubemap for diffuse SH.
 		int32 copyMip = badger::ctz(reflectionCubemap->getCreateParams().width) - badger::ctz(ambientCubemap->getCreateParams().width);
 		LightProbeBaker::get().copyCubemap_renderThread(cmdList, reflectionCubemap, ambientCubemap, copyMip, 0);
 	}

--- a/projects/PathosEngine/src/pathos/render/sky_panorama.cpp
+++ b/projects/PathosEngine/src/pathos/render/sky_panorama.cpp
@@ -78,7 +78,6 @@ namespace pathos {
 
 		renderToScreen(cmdList, scene);
 
-		// #wip: Sky lighting flickers? (world_rc1)
 		if (scene->panoramaSky->bLightingDirty) {
 			const ESkyLightingUpdateMode mode = scene->panoramaSky->lightingMode;
 			const ESkyLightingUpdatePhase phase = scene->panoramaSky->lightingPhase;

--- a/projects/PathosEngine/src/pathos/render/sky_panorama.h
+++ b/projects/PathosEngine/src/pathos/render/sky_panorama.h
@@ -20,9 +20,10 @@ namespace pathos {
 
 	private:
 		void renderToScreen(RenderCommandList& cmdList, SceneProxy* scene);
-		void renderToCubemap(RenderCommandList& cmdList, SceneProxy* scene);
-		void renderSkyDiffuseSH(RenderCommandList& cmdList);
-		void renderSkyPrefilterMap(RenderCommandList& cmdList);
+		void renderToCubemap(RenderCommandList& cmdList, SceneProxy* scene, int32 faceBegin, int32 faceEnd); // faces inclusive
+		void generateCubemapMips(RenderCommandList& cmdList);
+		void computeDiffuseSH(RenderCommandList& cmdList);
+		void filterSpecular(RenderCommandList& cmdList);
 
 		GLuint fbo = 0xffffffff;
 		UniformBuffer ubo;

--- a/projects/PathosEngine/src/pathos/render/skybox.cpp
+++ b/projects/PathosEngine/src/pathos/render/skybox.cpp
@@ -238,8 +238,9 @@ namespace pathos {
 	void SkyboxPass::generateCubemapMips(RenderCommandList& cmdList) {
 		SCOPED_DRAW_EVENT(SkyboxMips);
 
-		// Copy specular cubemap to ambient cubemap for diffuse SH.
 		cmdList.generateTextureMipmap(reflectionCubemap->internal_getGLName());
+
+		// Copy specular cubemap to ambient cubemap for diffuse SH.
 		int32 copyMip = badger::ctz(reflectionCubemap->getCreateParams().width) - badger::ctz(ambientCubemap->getCreateParams().width);
 		LightProbeBaker::get().copyCubemap_renderThread(cmdList, reflectionCubemap, ambientCubemap, copyMip, 0);
 	}

--- a/projects/PathosEngine/src/pathos/render/skybox.cpp
+++ b/projects/PathosEngine/src/pathos/render/skybox.cpp
@@ -62,7 +62,7 @@ namespace pathos {
 		cmdList.objectLabel(GL_FRAMEBUFFER, fboCube, -1, "FBO_SkyMaterialToCube");
 		cmdList.namedFramebufferDrawBuffer(fboCube, GL_COLOR_ATTACHMENT0);
 
-		const uint32 reflectionCubeSize = pathos::SKY_PREFILTER_MAP_MIN_SIZE;
+		const uint32 reflectionCubeSize = pathos::SKY_PREFILTER_MAP_SIZE;
 		const uint32 ambientCubeSize = pathos::SKY_AMBIENT_CUBEMAP_SIZE;
 
 		const uint32 mipLevels = 1 + badger::ctz(reflectionCubeSize) - badger::ctz(ambientCubeSize);
@@ -226,7 +226,7 @@ namespace pathos {
 	void SkyboxPass::renderSkyPreftilerMap(RenderCommandList& cmdList) {
 		SCOPED_DRAW_EVENT(SkyboxToPrefilterMap);
 
-		constexpr uint32 targetCubemapSize = pathos::SKY_PREFILTER_MAP_DEFAULT_SIZE;
+		constexpr uint32 targetCubemapSize = pathos::SKY_PREFILTER_MAP_SIZE;
 
 		SceneRenderTargets& sceneContext = *cmdList.sceneRenderTargets;
 		sceneContext.reallocSkyPrefilterMap(cmdList, targetCubemapSize);

--- a/projects/PathosEngine/src/pathos/render/skybox.h
+++ b/projects/PathosEngine/src/pathos/render/skybox.h
@@ -21,9 +21,11 @@ namespace pathos {
 
 	private:
 		void renderSkyboxToScreen(RenderCommandList& cmdList, SceneProxy* scene);
-		void renderSkyMaterialToCubemap(RenderCommandList& cmdList, SceneProxy* scene);
-		void renderSkyDiffuseSH(RenderCommandList& cmdList);
-		void renderSkyPreftilerMap(RenderCommandList& cmdList);
+		void renderToCubemap(RenderCommandList& cmdList, SceneProxy* scene, int32 faceBegin, int32 faceEnd);
+		void renderSkyMaterialToCubemap(RenderCommandList& cmdList, SceneProxy* scene, int32 faceBegin, int32 faceEnd);
+		void generateCubemapMips(RenderCommandList& cmdList);
+		void computeDiffuseSH(RenderCommandList& cmdList);
+		void filterSpecular(RenderCommandList& cmdList);
 
 		GLuint fbo = 0xffffffff;
 		GLuint fboCube = 0xffffffff;

--- a/projects/PathosEngine/src/pathos/rhi/render_command_list.generated.h
+++ b/projects/PathosEngine/src/pathos/rhi/render_command_list.generated.h
@@ -6336,7 +6336,11 @@ void bindBuffersBase(
 	packet->target = target;
 	packet->first = first;
 	packet->count = count;
-	packet->buffers = storeParameter(count * sizeof(GLuint), buffers);
+	if (buffers != nullptr) {
+		packet->buffers = storeParameter(count * sizeof(GLuint), buffers);
+	} else {
+		packet->buffers = nullptr;
+	}
 }
 void bindBuffersRange(
 	GLenum target,

--- a/projects/PathosEngine/src/pathos/scene/sky_atmosphere_component.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_atmosphere_component.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "sky_common.h"
 #include "pathos/render/scene_proxy.h"
 #include "pathos/scene/scene_component.h"
+#include "pathos/scene/sky_common.h"
 #include "pathos/scene/directional_light_component.h"
 
 #include "badger/types/vector_types.h"

--- a/projects/PathosEngine/src/pathos/scene/sky_atmosphere_component.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_atmosphere_component.h
@@ -24,14 +24,15 @@ namespace pathos {
 				return;
 			}
 
-			const ESkyLightingUpdateMode updateMode = getSkyLightingUpdateMethod();
+			const bool bMainScene = (scene->sceneProxySource == SceneProxySource::MainScene);
+			const ESkyLightingUpdateMode updateMode = getSkyLightingUpdateMode();
 
 			SkyAtmosphereProxy* proxy = ALLOC_RENDER_PROXY<SkyAtmosphereProxy>(scene);
-			proxy->bLightingDirty = updateMode != ESkyLightingUpdateMode::Disabled;
+			proxy->bLightingDirty = bMainScene && (updateMode != ESkyLightingUpdateMode::Disabled);
 			proxy->lightingMode   = updateMode;
 			proxy->lightingPhase  = lightingUpdatePhase;
 
-			if (updateMode == ESkyLightingUpdateMode::Progressive) {
+			if (bMainScene && updateMode == ESkyLightingUpdateMode::Progressive) {
 				lightingUpdatePhase = getNextSkyLightingUpdatePhase(lightingUpdatePhase);
 			}
 

--- a/projects/PathosEngine/src/pathos/scene/sky_atmosphere_component.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_atmosphere_component.h
@@ -24,16 +24,6 @@ namespace pathos {
 				return;
 			}
 
-			if (scene->sceneProxySource == SceneProxySource::MainScene) {
-				vector3 sunIntensity = sun->illuminance * sun->color;
-				float intensityDelta = glm::length(sun->illuminance - lastSunIntensity);
-				float cosTheta = glm::dot(sun->direction, lastSunDirectionWS);
-				if (intensityDelta > 0.1f || cosTheta < 0.99f) {
-					lastSunIntensity = sunIntensity;
-					lastSunDirectionWS = sun->direction;
-				}
-			}
-
 			const ESkyLightingUpdateMode updateMode = getSkyLightingUpdateMethod();
 
 			SkyAtmosphereProxy* proxy = ALLOC_RENDER_PROXY<SkyAtmosphereProxy>(scene);
@@ -42,19 +32,13 @@ namespace pathos {
 			proxy->lightingPhase  = lightingUpdatePhase;
 
 			if (updateMode == ESkyLightingUpdateMode::Progressive) {
-				lightingUpdatePhase = (ESkyLightingUpdatePhase)((uint32)lightingUpdatePhase + 1);
-				if (lightingUpdatePhase == ESkyLightingUpdatePhase::MAX) {
-					lightingUpdatePhase = (ESkyLightingUpdatePhase)0;
-				}
+				lightingUpdatePhase = getNextSkyLightingUpdatePhase(lightingUpdatePhase);
 			}
 
 			scene->skyAtmosphere = proxy;
 		}
 
 	private:
-		vector3 lastSunIntensity   = vector3(0.0f);
-		vector3 lastSunDirectionWS = vector3(0.0f);
-
 		ESkyLightingUpdatePhase lightingUpdatePhase = (ESkyLightingUpdatePhase)0;
 
 	};

--- a/projects/PathosEngine/src/pathos/scene/sky_common.cpp
+++ b/projects/PathosEngine/src/pathos/scene/sky_common.cpp
@@ -7,7 +7,7 @@ namespace pathos {
 
 	static ConsoleVariable<int32> cvar_skyLightingUpdateMode("r.skyLightingUpdateMode", 1, "0 = disable, 1 = progressive, 2 = every frame");
 	
-	ESkyLightingUpdateMode getSkyLightingUpdateMethod() {
+	ESkyLightingUpdateMode getSkyLightingUpdateMode() {
 		int32 value = cvar_skyLightingUpdateMode.getInt();
 		value = badger::clamp(0, value, 2);
 		return (ESkyLightingUpdateMode)value;

--- a/projects/PathosEngine/src/pathos/scene/sky_common.cpp
+++ b/projects/PathosEngine/src/pathos/scene/sky_common.cpp
@@ -13,4 +13,12 @@ namespace pathos {
 		return (ESkyLightingUpdateMode)value;
 	}
 
+	pathos::ESkyLightingUpdatePhase getNextSkyLightingUpdatePhase(ESkyLightingUpdatePhase current) {
+		current = (ESkyLightingUpdatePhase)((uint32)current + 1);
+		if (current == ESkyLightingUpdatePhase::MAX) {
+			current = (ESkyLightingUpdatePhase)0;
+		}
+		return current;
+	}
+
 }

--- a/projects/PathosEngine/src/pathos/scene/sky_common.cpp
+++ b/projects/PathosEngine/src/pathos/scene/sky_common.cpp
@@ -1,0 +1,16 @@
+#include "sky_common.h"
+#include "pathos/console.h"
+
+#include "badger/math/minmax.h"
+
+namespace pathos {
+
+	static ConsoleVariable<int32> cvar_skyLightingUpdateMode("r.skyLightingUpdateMode", 1, "0 = disable, 1 = progressive, 2 = every frame");
+	
+	ESkyLightingUpdateMode getSkyLightingUpdateMethod() {
+		int32 value = cvar_skyLightingUpdateMode.getInt();
+		value = badger::clamp(0, value, 2);
+		return (ESkyLightingUpdateMode)value;
+	}
+
+}

--- a/projects/PathosEngine/src/pathos/scene/sky_common.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_common.h
@@ -21,7 +21,7 @@ namespace pathos {
 		EveryFrame     = 2,
 	};
 
-	ESkyLightingUpdateMode getSkyLightingUpdateMethod();
+	ESkyLightingUpdateMode getSkyLightingUpdateMode();
 
 	ESkyLightingUpdatePhase getNextSkyLightingUpdatePhase(ESkyLightingUpdatePhase current);
 

--- a/projects/PathosEngine/src/pathos/scene/sky_common.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_common.h
@@ -23,4 +23,6 @@ namespace pathos {
 
 	ESkyLightingUpdateMode getSkyLightingUpdateMethod();
 
+	ESkyLightingUpdatePhase getNextSkyLightingUpdatePhase(ESkyLightingUpdatePhase current);
+
 }

--- a/projects/PathosEngine/src/pathos/scene/sky_common.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_common.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace pathos {
+
+	enum class ESkyLightingUpdatePhase : uint32 {
+		RenderFacePosX = 0,
+		RenderFaceNegX = 1,
+		RenderFacePosY = 2,
+		RenderFaceNegY = 3,
+		RenderFacePosZ = 4,
+		RenderFaceNegZ = 5,
+		GenerateMips   = 6,
+		DiffuseSH      = 7,
+		SpecularFilter = 8,
+		MAX            = 9,
+	};
+
+	enum class ESkyLightingUpdateMode : uint32 {
+		Disabled       = 0,
+		Progressive    = 1,
+		EveryFrame     = 2,
+	};
+
+	ESkyLightingUpdateMode getSkyLightingUpdateMethod();
+
+}

--- a/projects/PathosEngine/src/pathos/scene/sky_panorama_component.cpp
+++ b/projects/PathosEngine/src/pathos/scene/sky_panorama_component.cpp
@@ -142,7 +142,6 @@ namespace pathos {
 		if (sphere == nullptr) {
 			sphere = new IcosahedronGeometry(0);
 		}
-		bLightingDirty = true;
 	}
 
 	void PanoramaSkyComponent::createRenderProxy(SceneProxy* scene) {
@@ -151,15 +150,18 @@ namespace pathos {
 			return;
 		}
 
-		bool bMainScene = (scene->sceneProxySource == SceneProxySource::MainScene);
+		const bool bMainScene = (scene->sceneProxySource == SceneProxySource::MainScene);
+		const ESkyLightingUpdateMode lightingUpdateMode = getSkyLightingUpdateMode();
 
 		PanoramaSkyProxy* proxy = ALLOC_RENDER_PROXY<PanoramaSkyProxy>(scene);
 		proxy->sphere = sphere;
 		proxy->texture = texture;
-		proxy->bLightingDirty = bLightingDirty && bMainScene;
+		proxy->bLightingDirty = bMainScene;
+		proxy->lightingMode = lightingUpdateMode;
+		proxy->lightingPhase = lightingUpdatePhase;
 
-		if (bMainScene) {
-			bLightingDirty = false;
+		if (bMainScene && lightingUpdateMode == ESkyLightingUpdateMode::Progressive) {
+			lightingUpdatePhase = getNextSkyLightingUpdatePhase(lightingUpdatePhase);
 		}
 
 		scene->panoramaSky = proxy;

--- a/projects/PathosEngine/src/pathos/scene/sky_panorama_component.h
+++ b/projects/PathosEngine/src/pathos/scene/sky_panorama_component.h
@@ -4,6 +4,7 @@
 #include "pathos/rhi/texture.h"
 #include "pathos/mesh/geometry.h"
 #include "pathos/scene/scene_component.h"
+#include "pathos/scene/sky_common.h"
 
 namespace pathos {
 
@@ -39,6 +40,8 @@ namespace pathos {
 		MeshGeometry* sphere;
 		Texture* texture;
 		bool bLightingDirty;
+		ESkyLightingUpdateMode lightingMode;
+		ESkyLightingUpdatePhase lightingPhase;
 	};
 
 	class PanoramaSkyComponent : public SceneComponent {
@@ -47,8 +50,6 @@ namespace pathos {
 		~PanoramaSkyComponent();
 
 		// Pass a panorama-style texture (i.e., equirectangular map).
-		// Sky lighting is marked as dirty and will be updated automatically.
-		// NOTE: The update happens even if the same Texture instance is set.
 		void setTexture(Texture* texture);
 
 		inline bool hasValidResources() const {
@@ -61,8 +62,7 @@ namespace pathos {
 	private:
 		Texture* texture = nullptr;
 		MeshGeometry* sphere = nullptr;
-
-		bool bLightingDirty = false;
+		ESkyLightingUpdatePhase lightingUpdatePhase = (ESkyLightingUpdatePhase)0;
 	};
 
 }

--- a/projects/PathosEngine/src/pathos/scene/skybox_component.h
+++ b/projects/PathosEngine/src/pathos/scene/skybox_component.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pathos/scene/scene_component.h"
+#include "pathos/scene/sky_common.h"
 #include "pathos/mesh/geometry_primitive.h"
 
 namespace pathos {
@@ -9,13 +10,15 @@ namespace pathos {
 	class Material;
 
 	struct SkyboxProxy : SceneComponentProxy {
-		CubeGeometry*    cube;
-		Texture*         texture;
-		float            textureLod;
-		float            intensityMultiplier;
-		Material*        skyboxMaterial;
-		bool             bUseCubemapTexture;
-		bool             bLightingDirty;
+		CubeGeometry*           cube;
+		Texture*                texture;
+		float                   textureLod;
+		float                   intensityMultiplier;
+		Material*               skyboxMaterial;
+		bool                    bUseCubemapTexture;
+		bool                    bLightingDirty;
+		ESkyLightingUpdateMode  lightingMode;
+		ESkyLightingUpdatePhase lightingPhase;
 	};
 
 	class SkyboxComponent : public SceneComponent {
@@ -47,7 +50,7 @@ namespace pathos {
 
 		Material* skyboxMaterial = nullptr;
 
-		bool bLightingDirty = false;
+		ESkyLightingUpdatePhase lightingUpdatePhase = (ESkyLightingUpdatePhase)0;
 	};
 
 }

--- a/shaders/compute_diffuse_sh.glsl
+++ b/shaders/compute_diffuse_sh.glsl
@@ -86,6 +86,7 @@ void prefilter(uint face, uint x0, uint y0) {
         s_weight[face][y0][x0] = wSum;
     }
     memoryBarrierShared();
+    barrier();
 }
 
 void main() {
@@ -99,6 +100,7 @@ void main() {
         s_weight[face][tid.y][tid.x] = 0.0;
     }
     memoryBarrierShared();
+    barrier();
 
     prefilter(face, tid.x, tid.y);
 
@@ -124,10 +126,12 @@ void main() {
             }
         }
         memoryBarrierShared();
+        barrier();
 
         s_perFaceWeight[face] = wSum;
         for (int i = 0; i < 9; i++) s_perFaceL[face][i] = scratch[i];
         memoryBarrierShared();
+        barrier();
     }
 
     if (tid == uvec3(0, 0, 0)) {

--- a/shaders/compute_diffuse_sh.glsl
+++ b/shaders/compute_diffuse_sh.glsl
@@ -80,11 +80,12 @@ void prefilter(uint face, uint x0, uint y0) {
             wSum += w;
         }
     }
-
+    
     for (int i = 0; i < 9; i++) {
         s_sliceL[y0][x0][i] = scratch[i];
         s_weight[face][y0][x0] = wSum;
     }
+    memoryBarrierShared();
 }
 
 void main() {
@@ -100,7 +101,6 @@ void main() {
     memoryBarrierShared();
 
     prefilter(face, tid.x, tid.y);
-    memoryBarrierShared();
 
     // Collect per-face data.
     if (tid.xy == uvec2(0, 0)) {
@@ -123,10 +123,12 @@ void main() {
                 wSum += s_weight[face][y][x];
             }
         }
+        memoryBarrierShared();
+
         s_perFaceWeight[face] = wSum;
         for (int i = 0; i < 9; i++) s_perFaceL[face][i] = scratch[i];
+        memoryBarrierShared();
     }
-    memoryBarrierShared();
 
     if (tid == uvec3(0, 0, 0)) {
         float wSum = 0.0;

--- a/shaders/compute_diffuse_sh.glsl
+++ b/shaders/compute_diffuse_sh.glsl
@@ -8,8 +8,9 @@
 // --------------------------------------------------------
 // Definitions
 
-#define GROUP_SIZE_X 8
-#define GROUP_SIZE_Y 8
+// 8x8 is too big for shared memory
+#define GROUP_SIZE_X 4
+#define GROUP_SIZE_Y 4
 
 // --------------------------------------------------------
 // Layout
@@ -26,7 +27,7 @@ layout (std140, binding = 2) writeonly buffer Buffer_SH {
 
 shared vec3 s_perFaceL[6][9];
 shared float s_perFaceWeight[6];
-shared vec3 s_sliceL[GROUP_SIZE_Y][GROUP_SIZE_X][9];
+shared vec3 s_sliceL[6][GROUP_SIZE_Y][GROUP_SIZE_X][9];
 shared float s_weight[6][GROUP_SIZE_Y][GROUP_SIZE_X];
 
 // --------------------------------------------------------
@@ -82,7 +83,7 @@ void prefilter(uint face, uint x0, uint y0) {
     }
     
     for (int i = 0; i < 9; i++) {
-        s_sliceL[y0][x0][i] = scratch[i];
+        s_sliceL[face][y0][x0][i] = scratch[i];
         s_weight[face][y0][x0] = wSum;
     }
     memoryBarrierShared();
@@ -96,7 +97,7 @@ void main() {
     s_perFaceWeight[face] = 0.0;
     for (int i = 0; i < 9; i++) {
         s_perFaceL[face][i] = vec3(0);
-        s_sliceL[tid.y][tid.x][i] = vec3(0);
+        s_sliceL[face][tid.y][tid.x][i] = vec3(0);
         s_weight[face][tid.y][tid.x] = 0.0;
     }
     memoryBarrierShared();
@@ -112,15 +113,15 @@ void main() {
 
         for (uint y = 0; y < GROUP_SIZE_Y; y++) {
             for (uint x = 0; x < GROUP_SIZE_X; x++) {
-                scratch[0] += s_sliceL[y][x][0];
-                scratch[1] += s_sliceL[y][x][1];
-                scratch[2] += s_sliceL[y][x][2];
-                scratch[3] += s_sliceL[y][x][3];
-                scratch[4] += s_sliceL[y][x][4];
-                scratch[5] += s_sliceL[y][x][5];
-                scratch[6] += s_sliceL[y][x][6];
-                scratch[7] += s_sliceL[y][x][7];
-                scratch[8] += s_sliceL[y][x][8];
+                scratch[0] += s_sliceL[face][y][x][0];
+                scratch[1] += s_sliceL[face][y][x][1];
+                scratch[2] += s_sliceL[face][y][x][2];
+                scratch[3] += s_sliceL[face][y][x][3];
+                scratch[4] += s_sliceL[face][y][x][4];
+                scratch[5] += s_sliceL[face][y][x][5];
+                scratch[6] += s_sliceL[face][y][x][6];
+                scratch[7] += s_sliceL[face][y][x][7];
+                scratch[8] += s_sliceL[face][y][x][8];
 
                 wSum += s_weight[face][y][x];
             }

--- a/shaders/debugging/visualize_buffer.glsl
+++ b/shaders/debugging/visualize_buffer.glsl
@@ -3,6 +3,7 @@
 #version 460 core
 
 #include "deferred_common.glsl"
+#include "core/diffuse_sh.glsl"
 
 // Should match with 'r.viewmode'
 #define VIEWMODE_SCENEDEPTH  1
@@ -15,6 +16,7 @@
 #define VIEWMODE_SSR         8
 #define VIEWMODE_VELOCITY    9
 #define VIEWMODE_CSMLAYER    10
+#define VIEWMODE_SKY_SH      11
 
 in VS_OUT {
 	vec2 screenUV;
@@ -23,6 +25,10 @@ in VS_OUT {
 layout (std140, binding = 1) uniform UBO_VisualizeBuffer {
 	int viewmode;
 } ubo;
+
+layout (std140, binding = 2) readonly buffer SSBO_SkyDiffuseSH {
+	SHBuffer shBuffer;
+} ssboSkyDiffuseSH;
 
 layout (binding = 0) uniform sampler2D sceneDepth;
 layout (binding = 1) uniform usampler2D gbuf0;
@@ -83,5 +89,9 @@ void main() {
 		} else {
 			outColor = vec4(1.0, 0.0, 0.0, 1.0);
 		}
+	} else if (viewmode == VIEWMODE_SKY_SH) {
+		vec3 dir = gbufferData.ws_normal;
+		vec3 color = evaluateSH(ssboSkyDiffuseSH.shBuffer, dir);
+		outColor = vec4(color, 1);
 	}
 }


### PR DESCRIPTION
- Implement progressive update of sky lighting across 8 frames for all sky sources (skybox, panorama sky, and sky atmosphere).
- Add cvar "r.skyLightingUpdateMode" that affects currently active sky actor.
- Add sky diffuse SH mode for "r.viewmode" console command (`r.viewmode 11`).
- Fix memory bugs in diffuse SH shader.
- Change size of sky ambient cubemap (forced to 64).
- Change size of sky reflection cubemap (forced to 128).
- Change mip count of sky reflection cubemap (forced to 7).
- Fix null ptr crash for RenderCommandList::bindBuffersBase().

